### PR TITLE
Extend "new" function for supporting uglify after av.object.extend .

### DIFF
--- a/lib/av.js
+++ b/lib/av.js
@@ -5644,6 +5644,9 @@
       return AV.Object.extend.apply(NewClassObject, newArguments);
     };
     AV.Object._classMap[className] = NewClassObject;
+    NewClassObject.new = function() {
+      return new NewClassObject();
+    };
     return NewClassObject;
   };
 


### PR DESCRIPTION
Use case:

```
var whatever = AV.Object.extend("TestObject");
var testObject = whatever.new();
whatever.save({
    foo: "bar"
}, {
    success: function(object) {
        alert("AVOS Cloud works!");
    }
});
```
