### PR TITLE
Set ACL only when ACL is not exists yet.

### DIFF
--- a/lib/role.js
+++ b/lib/role.js
@@ -36,12 +36,14 @@ module.exports = function(AV) {
       if (acl === undefined) {
         var defaultAcl = new AV.ACL();
         defaultAcl.setPublicReadAccess(true);
-        acl = defaultAcl;
-      }
-      if (!(acl instanceof AV.ACL)) {
+        if(!this.getACL()) {
+          this.setACL(defaultAcl);
+        }
+      } else if (!(acl instanceof AV.ACL)) {
         throw new TypeError('acl must be an instance of AV.ACL');
+      } else {
+        this.setACL(acl);
       }
-      this.setACL(acl);
     },
 
     /**


### PR DESCRIPTION

处理一种边缘情况：

```js
new AV.Role({
  ACL:  new AV.ACL……
});
```

理论上用户可以这样设置  ACL 属性的。