### PR TITLE
[fix] Replace xhr.upload.addEventListener with onprogress.

### DIFF
--- a/lib/browserify-wrapper/upload-browser.js
+++ b/lib/browserify-wrapper/upload-browser.js
@@ -24,11 +24,9 @@ module.exports = function upload(file, AV, saveOptions) {
 
     var xhr = new AV.XMLHttpRequest();
 
-    xhr.upload.addEventListener('progress', function(e) {
-      if (e.lengthComputable) {
-        saveOptions.onProgress && saveOptions.onProgress(e);
-      }
-    }, false);
+    if (xhr.upload) {
+      xhr.upload.onprogress = saveOptions.onProgress;
+    }
 
     xhr.onreadystatechange = function() {
       if (xhr.readyState === 4) {


### PR DESCRIPTION
In some versions of React Native, xhr.upload.addEventListener is not implemented.