### PR TITLE
[feat] Support route 'installations'.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -386,6 +386,7 @@ module.exports = function(AV) {
         route !== 'search/select' &&
         route !== 'subscribe/statuses/count' &&
         route !== 'subscribe/statuses' &&
+        route !== 'installations' &&
         !(/users\/[^\/]+\/updatePassword/.test(route)) &&
         !(/users\/[^\/]+\/friendship\/[^\/]+/.test(route))) {
       throw "Bad route: '" + route + "'.";


### PR DESCRIPTION
`AV._request` is used in https://github.com/leancloud/javascript-sdk-installation-plugin. 需要访问 `/installation` route.