### PR TITLE
[fix] Use square bracket notation.

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -1291,7 +1291,7 @@ module.exports = function(AV) {
    * @see AV.Object
    * @see AV.Object.extend
    */
-  AV.Object.new = function(attributes, options){
+  AV.Object['new'] = function(attributes, options){
     return new AV.Object(attributes, options);
   };
 
@@ -1360,7 +1360,7 @@ module.exports = function(AV) {
       var newArguments = [className].concat(AV._.toArray(arguments));
       return AV.Object.extend.apply(NewClassObject, newArguments);
     };
-    NewClassObject.new = function(attributes, options){
+    NewClassObject['new'] = function(attributes, options){
       return new NewClassObject(attributes, options);
     };
     AV.Object._classMap[className] = NewClassObject;


### PR DESCRIPTION
`Object.new` cause SyntaxError in IE8.