### PR TITLE
Disable current user

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "gulp-sourcemaps": "^1.6.0",
     "gulp-tar": "^1.3.2",
     "gulp-uglify": "^1.0.2",
-    "mocha": "1.9.0",
+    "mocha": "2.4.5",
     "vinyl-source-stream": "^1.1.0"
   },
   "license": "MIT",

--- a/src/cloudfunction.js
+++ b/src/cloudfunction.js
@@ -31,7 +31,7 @@ module.exports = function(AV) {
      * of the function.
      */
     run: function(name, data, options) {
-      var request = AV._request("functions", name, null, 'POST',
+      var request = AV._request('functions', name, null, 'POST',
                                    AV._encode(data, null, true), options && options.sessionToken);
 
       return request.then(function(resp) {

--- a/src/cloudfunction.js
+++ b/src/cloudfunction.js
@@ -32,7 +32,7 @@ module.exports = function(AV) {
      */
     run: function(name, data, options) {
       var request = AV._request("functions", name, null, 'POST',
-                                   AV._encode(data, null, true));
+                                   AV._encode(data, null, true), options && options.sessionToken);
 
       return request.then(function(resp) {
         return AV._decode(null, resp).result;

--- a/src/file.js
+++ b/src/file.js
@@ -539,7 +539,7 @@ module.exports = function(AV) {
     destroy: function(options){
       if(!this.id)
         return AV.Promise.error('The file id is not eixsts.')._thenRunCallbacks(options);
-      var request = AV._request("files", null, this.id, 'DELETE');
+      var request = AV._request("files", null, this.id, 'DELETE', options && options.sessionToken);
       return request._thenRunCallbacks(options);
     },
 

--- a/src/file.js
+++ b/src/file.js
@@ -342,15 +342,20 @@ module.exports = function(AV) {
     // 用来存储转换后要上传的 base64 String
     this._base64 = '';
 
-    var currentUser;
-    try {
-      currentUser = AV.User.current();
+    let owner;
+
+    if (data && data.owner) {
+      owner = data.owner;
+    } else {
+      try {
+        owner = AV.User.current();
+      } catch (e) {
+        console.warn('Get current user failed. It seems this runtime use an async storage system, please new AV.File in the callback of AV.User.currentAsync().');
+      }
     }
-    catch (e) {
-      console.warn('Get current user failed. It seems this runtime use an async storage system, please new AV.File in the callback of AV.User.currentAsync().');
-    }
+
     this._metaData = {
-       owner: (currentUser ? currentUser.id : 'unknown')
+       owner: (owner ? owner.id : 'unknown')
     };
 
     // Guess the content type from the extension if we need to.

--- a/src/object.js
+++ b/src/object.js
@@ -791,7 +791,7 @@ module.exports = function(AV) {
       }
 
       var self = this;
-      var request = AV._request("classes", this.className, this.id, 'GET',
+      var request = AV._request('classes', this.className, this.id, 'GET',
                                 fetchOptions, options.sessionToken);
       return request.then(function(response) {
         self._finishFetch(self.parse(response), true);
@@ -977,7 +977,7 @@ module.exports = function(AV) {
       }
 
       var request =
-          AV._request("classes", this.className, this.id, 'DELETE', null, options.sessionToken);
+          AV._request('classes', this.className, this.id, 'DELETE', null, options.sessionToken);
       return request.then(function() {
         if (options.wait) {
           triggerDestroy();
@@ -1247,7 +1247,7 @@ module.exports = function(AV) {
           }
       });
       var request =
-          AV._request("classes", className, id, 'DELETE', null, options.sessionToken);
+          AV._request('classes', className, id, 'DELETE', null, options.sessionToken);
       return request._thenRunCallbacks(options);
    };
 

--- a/src/object.js
+++ b/src/object.js
@@ -111,7 +111,7 @@ module.exports = function(AV) {
    * @param {Object} options A Backbone-style callback object.
    */
   AV.Object.saveAll = function(list, options) {
-    return AV.Object._deepSaveAsync(list)._thenRunCallbacks(options);
+    return AV.Object._deepSaveAsync(list, null, options)._thenRunCallbacks(options);
   };
 
   // Attach all inheritable methods to the AV.Object prototype.
@@ -792,7 +792,7 @@ module.exports = function(AV) {
 
       var self = this;
       var request = AV._request("classes", this.className, this.id, 'GET',
-                                fetchOptions);
+                                fetchOptions, options.sessionToken);
       return request.then(function(response) {
         self._finishFetch(self.parse(response), true);
         return self;
@@ -891,15 +891,13 @@ module.exports = function(AV) {
       // If there is any unsaved child, save it first.
       model._refreshCache();
 
-
-
       var unsavedChildren = [];
       var unsavedFiles = [];
       AV.Object._findUnsavedChildren(model.attributes,
                                         unsavedChildren,
                                         unsavedFiles);
       if (unsavedChildren.length + unsavedFiles.length > 0) {
-        return AV.Object._deepSaveAsync(this.attributes, model).then(function() {
+        return AV.Object._deepSaveAsync(this.attributes, model, options).then(function() {
           return model.save(null, options);
         }, function(error) {
           return AV.Promise.error(error)._thenRunCallbacks(options, model);
@@ -929,7 +927,7 @@ module.exports = function(AV) {
         }
         //hook makeRequest in options.
         var makeRequest = options._makeRequest || AV._request;
-        var request = makeRequest(route, className, model.id, method, json);
+        var request = makeRequest(route, className, model.id, method, json, options.sessionToken);
 
         request = request.then(function(resp) {
           var serverAttrs = model.parse(resp);
@@ -979,7 +977,7 @@ module.exports = function(AV) {
       }
 
       var request =
-          AV._request("classes", this.className, this.id, 'DELETE');
+          AV._request("classes", this.className, this.id, 'DELETE', null, options.sessionToken);
       return request.then(function() {
         if (options.wait) {
           triggerDestroy();
@@ -1229,6 +1227,7 @@ module.exports = function(AV) {
     *     completes.
     */
    AV.Object.destroyAll = function(objects, options){
+      options = options || {}
       if(objects == null || objects.length == 0){
 		  return AV.Promise.as()._thenRunCallbacks(options);
       }
@@ -1248,7 +1247,7 @@ module.exports = function(AV) {
           }
       });
       var request =
-          AV._request("classes", className, id, 'DELETE');
+          AV._request("classes", className, id, 'DELETE', null, options.sessionToken);
       return request._thenRunCallbacks(options);
    };
 
@@ -1415,7 +1414,7 @@ module.exports = function(AV) {
     return canBeSerializedAsValue;
   };
 
-  AV.Object._deepSaveAsync = function(object, model) {
+  AV.Object._deepSaveAsync = function(object, model, options) {
     var unsavedChildren = [];
     var unsavedFiles = [];
     AV.Object._findUnsavedChildren(object, unsavedChildren, unsavedFiles);
@@ -1496,7 +1495,7 @@ module.exports = function(AV) {
               };
             })
 
-          }).then(function(response) {
+          }, options && options.sessionToken).then(function(response) {
             var error;
             AV._arrayEach(batch, function(object, i) {
               if (response[i].success) {

--- a/src/query.js
+++ b/src/query.js
@@ -155,7 +155,7 @@ module.exports = function(AV) {
       options = pvalues;
     }
 
-    var request = AV._request("cloudQuery", null, null, 'GET', params);
+    var request = AV._request("cloudQuery", null, null, 'GET', params, options && options.sessionToken);
     return request.then(function(response) {
       //query to process results.
       var query = new AV.Query(response.className);
@@ -251,9 +251,9 @@ module.exports = function(AV) {
       }
       return obj;
     },
-    _createRequest: function(params){
+    _createRequest: function(params, options){
       return AV._request("classes", this.className, null, "GET",
-                                   params || this.toJSON());
+                                   params || this.toJSON(), options && options.sessionToken);
     },
 
     /**
@@ -268,7 +268,7 @@ module.exports = function(AV) {
     find: function(options) {
       var self = this;
 
-      var request = this._createRequest();
+      var request = this._createRequest(null, options);
 
       return request.then(function(response) {
         return _.map(response.results, function(json) {
@@ -306,7 +306,7 @@ module.exports = function(AV) {
       var params = this.toJSON();
       params.limit = 0;
       params.count = 1;
-      var request = this._createRequest(params);
+      var request = this._createRequest(params, options);
 
       return request.then(function(response) {
         return response.count;
@@ -328,7 +328,7 @@ module.exports = function(AV) {
 
       var params = this.toJSON();
       params.limit = 1;
-      var request = this._createRequest(params);
+      var request = this._createRequest(params, options);
 
       return request.then(function(response) {
         return _.map(response.results, function(json) {

--- a/src/query.js
+++ b/src/query.js
@@ -155,7 +155,7 @@ module.exports = function(AV) {
       options = pvalues;
     }
 
-    var request = AV._request("cloudQuery", null, null, 'GET', params, options && options.sessionToken);
+    var request = AV._request('cloudQuery', null, null, 'GET', params, options && options.sessionToken);
     return request.then(function(response) {
       //query to process results.
       var query = new AV.Query(response.className);
@@ -252,7 +252,7 @@ module.exports = function(AV) {
       return obj;
     },
     _createRequest: function(params, options){
-      return AV._request("classes", this.className, null, "GET",
+      return AV._request('classes', this.className, null, "GET",
                                    params || this.toJSON(), options && options.sessionToken);
     },
 

--- a/src/search.js
+++ b/src/search.js
@@ -125,7 +125,7 @@ module.exports = function(AV) {
      _highlights: null,
      _sortBuilder: null,
     _createRequest: function(params, options){
-      return AV._request("search/select", null, null, "GET",
+      return AV._request('search/select', null, null, 'GET',
                                    params || this.toJSON(), options && options.sessionToken);
     },
 

--- a/src/search.js
+++ b/src/search.js
@@ -124,9 +124,9 @@ module.exports = function(AV) {
      _queryString: null,
      _highlights: null,
      _sortBuilder: null,
-    _createRequest: function(params){
+    _createRequest: function(params, options){
       return AV._request("search/select", null, null, "GET",
-                                   params || this.toJSON());
+                                   params || this.toJSON(), options && options.sessionToken);
     },
 
     /**

--- a/src/status.js
+++ b/src/status.js
@@ -58,7 +58,7 @@ module.exports = function(AV) {
     destroy: function(options){
       if(!this.id)
         return AV.Promise.error('The status id is not exists.')._thenRunCallbacks(options);
-      var request = AV._request("statuses", null, this.id, 'DELETE');
+      var request = AV._request("statuses", null, this.id, 'DELETE', options && options.sessionToken);
       return request._thenRunCallbacks(options);
     },
     /**
@@ -112,7 +112,7 @@ module.exports = function(AV) {
       data.data = this._getDataJSON();
       data.inboxType = this.inboxType || 'default';
 
-      var request = AV._request('statuses', null, null, 'POST', data);
+      var request = AV._request('statuses', null, null, 'POST', data, options && options.sessionToken);
       var self = this;
       return request.then(function(response){
         self.id = response.objectId;
@@ -169,7 +169,7 @@ module.exports = function(AV) {
     data.data = status._getDataJSON();
     data.inboxType = status.inboxType || 'default';
 
-    var request = AV._request('statuses', null, null, 'POST', data);
+    var request = AV._request('statuses', null, null, 'POST', data, options && options.sessionToken);
     return request.then(function(response){
       status.id = response.objectId;
       status.createdAt = AV._parseDate(response.createdAt);
@@ -222,7 +222,7 @@ module.exports = function(AV) {
     data.inboxType = 'private';
     status.inboxType = 'private';
 
-    var request = AV._request('statuses', null, null, 'POST', data);
+    var request = AV._request('statuses', null, null, 'POST', data, options && options.sessionToken);
     return request.then(function(response){
       status.id = response.objectId;
       status.createdAt = AV._parseDate(response.createdAt);
@@ -254,7 +254,7 @@ module.exports = function(AV) {
     var params = {};
     params.inboxType = AV._encode(inboxType);
     params.owner = AV._encode(owner);
-    var request = AV._request('subscribe/statuses/count', null, null, 'GET', params);
+    var request = AV._request('subscribe/statuses/count', null, null, 'GET', params, options && options.sessionToken);
     return request._thenRunCallbacks(options);
   };
 
@@ -293,9 +293,9 @@ module.exports = function(AV) {
      _newObject: function(){
       return new AV.Status();
     },
-    _createRequest: function(params){
+    _createRequest: function(params, options){
       return AV._request("subscribe/statuses", null, null, "GET",
-                                   params || this.toJSON());
+                                   params || this.toJSON(), options && options.sessionToken);
     },
 
 

--- a/src/status.js
+++ b/src/status.js
@@ -58,7 +58,7 @@ module.exports = function(AV) {
     destroy: function(options){
       if(!this.id)
         return AV.Promise.error('The status id is not exists.')._thenRunCallbacks(options);
-      var request = AV._request("statuses", null, this.id, 'DELETE', options && options.sessionToken);
+      var request = AV._request('statuses', null, this.id, 'DELETE', options && options.sessionToken);
       return request._thenRunCallbacks(options);
     },
     /**
@@ -294,7 +294,7 @@ module.exports = function(AV) {
       return new AV.Status();
     },
     _createRequest: function(params, options){
-      return AV._request("subscribe/statuses", null, null, "GET",
+      return AV._request('subscribe/statuses', null, null, 'GET',
                                    params || this.toJSON(), options && options.sessionToken);
     },
 

--- a/src/user.js
+++ b/src/user.js
@@ -796,7 +796,7 @@ module.exports = function(AV) {
      */
     logOut: function() {
       if (AV._config.disableCurrentUser) {
-        return console.warn('AV.User\'s currentUser disabled, use User#logOut instead');
+        return console.warn('AV.User.current() was disabled in multi-user environment, call logOut() from user object instead');
       }
 
       if (AV.User._currentUser !== null) {
@@ -977,7 +977,7 @@ module.exports = function(AV) {
      */
     currentAsync: function() {
       if (AV._config.disableCurrentUser) {
-        console.warn('AV.User\'s currentUser disabled, access user from request instead');
+        console.warn('AV.User.current() was disabled in multi-user environment, access user from request instead');
         return AV.Promise.as(null);
       }
 
@@ -1026,7 +1026,7 @@ module.exports = function(AV) {
      */
     current: function() {
       if (AV._config.disableCurrentUser) {
-        console.warn('AV.User\'s currentUser disabled, access user from request instead');
+        console.warn('AV.User.current() was disabled in multi-user environment, access user from request instead');
         return null;
       }
 

--- a/src/user.js
+++ b/src/user.js
@@ -96,7 +96,7 @@ module.exports = function(AV) {
 
     _handleSaveResult: function(makeCurrent) {
       // Clean up and synchronize the authData object, removing any unset values
-      if (makeCurrent && !AV.User._currentUserDisabled) {
+      if (makeCurrent && !AV._config.disableCurrentUser) {
         this._isCurrentUser = true;
       }
       this._cleanupAuthData();
@@ -105,7 +105,7 @@ module.exports = function(AV) {
       delete this._serverData.password;
       this._rebuildEstimatedDataForKey("password");
       this._refreshCache();
-      if ((makeCurrent || this.isCurrent()) && !AV.User._currentUserDisabled) {
+      if ((makeCurrent || this.isCurrent()) && !AV._config.disableCurrentUser) {
         // Some old version of leanengine-node-sdk will overwrite
         // AV.User._saveCurrentUser which returns no Promise.
         // So we need a Promise wrapper.
@@ -606,8 +606,6 @@ module.exports = function(AV) {
     // The mapping of auth provider names to actual providers
     _authProviders: {},
 
-    _currentUserDisabled: false,
-
     // Class Methods
 
     /**
@@ -797,7 +795,7 @@ module.exports = function(AV) {
      * <code>current</code> will return <code>null</code>.
      */
     logOut: function() {
-      if (AV.User._currentUserDisabled) {
+      if (AV._config.disableCurrentUser) {
         return console.warn('AV.User\'s currentUser disabled, use User#logOut instead');
       }
 
@@ -978,7 +976,7 @@ module.exports = function(AV) {
      * @return {AV.Promise} resolved with the currently logged in AV.User.
      */
     currentAsync: function() {
-      if (AV.User._currentUserDisabled) {
+      if (AV._config.disableCurrentUser) {
         console.warn('AV.User\'s currentUser disabled, access user from request instead');
         return AV.Promise.as(null);
       }
@@ -1027,7 +1025,7 @@ module.exports = function(AV) {
      * @return {AV.Object} The currently logged in AV.User.
      */
     current: function() {
-      if (AV.User._currentUserDisabled) {
+      if (AV._config.disableCurrentUser) {
         console.warn('AV.User\'s currentUser disabled, access user from request instead');
         return null;
       }
@@ -1065,10 +1063,6 @@ module.exports = function(AV) {
       AV.User._currentUser._refreshCache();
       AV.User._currentUser._opSetQueue = [{}];
       return AV.User._currentUser;
-    },
-
-    disableCurrentUser: function() {
-      AV.User._currentUserDisabled = true;
     },
 
     /**

--- a/src/user.js
+++ b/src/user.js
@@ -413,7 +413,7 @@ module.exports = function(AV) {
           throw "Invalid target user.";
       }
       var route = 'users/' + this.id + '/friendship/' + userObjectId;
-      var request = AV._request(route, null, null, 'POST', null);
+      var request = AV._request(route, null, null, 'POST', null, options && options.sessionToken);
       return request._thenRunCallbacks(options);
     },
 
@@ -437,7 +437,7 @@ module.exports = function(AV) {
           throw "Invalid target user.";
       }
       var route = 'users/' + this.id + '/friendship/' + userObjectId;
-      var request = AV._request(route, null, null, 'DELETE', null);
+      var request = AV._request(route, null, null, 'DELETE', null, options && options.sessionToken);
       return request._thenRunCallbacks(options);
     },
 
@@ -493,7 +493,7 @@ module.exports = function(AV) {
         old_password: oldPassword,
         new_password: newPassword
       };
-      var request = AV._request(route, null, null, 'PUT', params);
+      var request = AV._request(route, null, null, 'PUT', params, options && options.sessionToken);
       return request._thenRunCallbacks(options, this);
     },
 

--- a/src/user.js
+++ b/src/user.js
@@ -798,7 +798,7 @@ module.exports = function(AV) {
      */
     logOut: function() {
       if (AV.User._currentUserDisabled) {
-        return console.wran('AVUser.currentUser disabled, use User#logOut instead');
+        return console.warn('AV.User\'s currentUser disabled, use User#logOut instead');
       }
 
       if (AV.User._currentUser !== null) {
@@ -979,8 +979,8 @@ module.exports = function(AV) {
      */
     currentAsync: function() {
       if (AV.User._currentUserDisabled) {
-        console.wran('AVUser.currentUser disabled, access user from request instead');
-        return AV.Promise.as();
+        console.warn('AV.User\'s currentUser disabled, access user from request instead');
+        return AV.Promise.as(null);
       }
 
       if (AV.User._currentUser) {
@@ -1028,7 +1028,7 @@ module.exports = function(AV) {
      */
     current: function() {
       if (AV.User._currentUserDisabled) {
-        console.wran('AVUser.currentUser disabled, access user from request instead');
+        console.warn('AV.User\'s currentUser disabled, access user from request instead');
         return null;
       }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -403,7 +403,7 @@ const init = (AV) => {
     }).then(function() {
       // Pass the installation id
       if (!AV.User._currentUserDisabled) {
-        AV._getInstallationId().then(function(installationId) {
+        return AV._getInstallationId().then(function(installationId) {
           dataObject._InstallationId = installationId;
         });
       }

--- a/src/utils.js
+++ b/src/utils.js
@@ -315,7 +315,7 @@ const init = (AV) => {
    * dataObject is the payload as an object, or null if there is none.
    * @ignore
    */
-  AV._request = function(route, className, objectId, method, dataObject) {
+  AV._request = function(route, className, objectId, method, dataObject, sessionToken) {
     if (!AV.applicationId) {
       throw "You must specify your applicationId using AV.initialize";
     }
@@ -392,7 +392,7 @@ const init = (AV) => {
     // Pass the session token on every request.
     return AV.User.currentAsync().then(function(currentUser) {
       if (currentUser && currentUser._sessionToken) {
-        dataObject._SessionToken = currentUser._sessionToken;
+        dataObject._SessionToken = sessionToken || currentUser._sessionToken;
       }
       return AV._getInstallationId();
     }).then(function(_InstallationId) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,7 +28,10 @@ const init = (AV) => {
     APIServerURL: AVConfig.APIServerURL || '',
 
     // 当前是否为 nodejs 环境
-    isNode: false
+    isNode: false,
+
+    // 禁用 currentUser，通常用于多用户环境
+    disableCurrentUser: false
   });
 
   /**
@@ -154,6 +157,7 @@ const init = (AV) => {
           }
           initialize(options.appId, options.appKey, options.masterKey);
           setRegionServer(options.region);
+          AVConfig.disableCurrentUser = options.disableCurrentUser;
         } else {
           throw new Error('AV.init(): Parameter is not correct.');
         }
@@ -393,7 +397,7 @@ const init = (AV) => {
       // Pass the session token
       if (sessionToken) {
         dataObject._SessionToken = sessionToken;
-      } else if (!AV.User._currentUserDisabled) {
+      } else if (!AV._config.disableCurrentUser) {
         return AV.User.currentAsync().then(function(currentUser) {
           if (currentUser && currentUser._sessionToken) {
             dataObject._SessionToken = currentUser._sessionToken;
@@ -402,7 +406,7 @@ const init = (AV) => {
       }
     }).then(function() {
       // Pass the installation id
-      if (!AV.User._currentUserDisabled) {
+      if (!AV._config.disableCurrentUser) {
         return AV._getInstallationId().then(function(installationId) {
           dataObject._InstallationId = installationId;
         });

--- a/test/cloud.js
+++ b/test/cloud.js
@@ -18,13 +18,10 @@ describe("AV.Cloud", function() {
   });
 
   describe("#getServerDate", function(){
-    it("should return a date.", function(done){
-      AV.Cloud.getServerDate().then(function(date) {
+    it("should return a date.", function() {
+      return AV.Cloud.getServerDate().then(function(date) {
         expect(date).to.be.a('object');
         expect(date instanceof Date).to.be(true);
-        done();
-      }).catch(function(err) {
-        throw err;
       });
     });
   });

--- a/test/user.js
+++ b/test/user.js
@@ -281,4 +281,79 @@ describe("User", function() {
       });
     });
   });
+
+  describe('currentUser disabled', function() {
+    var user, originalUser;
+
+    before(function() {
+      originalUser = AV.User._currentUser;
+      AV.User._currentUser = null;
+      AV.User._currentUserDisabled = true;
+      AV._useMasterKey = false;
+    });
+
+    var username = 'u' + Date.now();
+    var email = 'u' + Date.now() + '@test.com';
+    var password = 'password1';
+
+    it('User#signUp', function() {
+      user = new AV.User();
+
+      user.set("username", username);
+      user.set("password", password);
+      user.set("email", email);
+
+      return user.signUp(null, {
+        success: function(user) {
+          expect(user._isCurrentUser).to.be.equal(false);
+          expect(AV.User._currentUser).to.be.equal(null);
+          expect(user._sessionToken).to.be.ok();
+        }
+      });
+    });
+
+    it('User#getSessionToken', function() {
+      expect(user.getSessionToken()).to.be.ok();
+    });
+
+    it('User.current', function() {
+      expect(AV.User.current()).to.be.equal(null);
+    });
+
+    it('User.currentAsync', function() {
+      AV.User.currentAsync().then(function(user) {
+        expect(user).to.be.equal(null);
+      });
+    });
+
+    it('User#save without token', function(done) {
+      user.save({username: username + 'changed'}, {
+        success: function() {
+          done(new Error('Should not success'));
+        },
+        error: function(err) {
+          expect(err.code).to.be.equal(206);
+          done();
+        }
+      });
+    });
+
+    it('User#save with token', function(done) {
+      user.save({username: username + 'changed'}, {
+        sessionToken: user.getSessionToken(),
+        success: function() {
+          done();
+        },
+        error: function(err) {
+          done(err);
+        }
+      });
+    });
+
+    after(function() {
+      AV.User._currentUserDisabled = false;
+      AV._useMasterKey = true;
+      AV.User._currentUser = originalUser;
+    });
+  });
 });

--- a/test/user.js
+++ b/test/user.js
@@ -288,7 +288,7 @@ describe("User", function() {
     before(function() {
       originalUser = AV.User._currentUser;
       AV.User._currentUser = null;
-      AV.User._currentUserDisabled = true;
+      AV._config.disableCurrentUser = true;
       AV._useMasterKey = false;
     });
 
@@ -343,7 +343,7 @@ describe("User", function() {
     });
 
     after(function() {
-      AV.User._currentUserDisabled = false;
+      AV._config.disableCurrentUser = false;
       AV._useMasterKey = true;
       AV.User._currentUser = originalUser;
     });

--- a/test/user.js
+++ b/test/user.js
@@ -283,13 +283,15 @@ describe("User", function() {
   });
 
   describe('currentUser disabled', function() {
-    var user, originalUser;
+    var user, originalUser, originalPromisesAPlusCompliant;
 
     before(function() {
       originalUser = AV.User._currentUser;
       AV.User._currentUser = null;
       AV._config.disableCurrentUser = true;
       AV._useMasterKey = false;
+      originalPromisesAPlusCompliant = AV.Promise._isPromisesAPlusCompliant;
+      AV.Promise._isPromisesAPlusCompliant = true;
     });
 
     var username = 'u' + Date.now();
@@ -346,6 +348,7 @@ describe("User", function() {
       AV._config.disableCurrentUser = false;
       AV._useMasterKey = true;
       AV.User._currentUser = originalUser;
+      AV.Promise._isPromisesAPlusCompliant = originalPromisesAPlusCompliant;
     });
   });
 });

--- a/test/user.js
+++ b/test/user.js
@@ -299,16 +299,14 @@ describe("User", function() {
     it('User#signUp', function() {
       user = new AV.User();
 
-      user.set("username", username);
-      user.set("password", password);
-      user.set("email", email);
+      user.set('username', username);
+      user.set('password', password);
+      user.set('email', email);
 
-      return user.signUp(null, {
-        success: function(user) {
-          expect(user._isCurrentUser).to.be.equal(false);
-          expect(AV.User._currentUser).to.be.equal(null);
-          expect(user._sessionToken).to.be.ok();
-        }
+      return user.signUp().then(function(user) {
+        expect(user._isCurrentUser).to.be.equal(false);
+        expect(AV.User._currentUser).to.be.equal(null);
+        expect(user._sessionToken).to.be.ok();
       });
     });
 
@@ -326,27 +324,21 @@ describe("User", function() {
       });
     });
 
-    it('User#save without token', function(done) {
-      user.save({username: username + 'changed'}, {
-        success: function() {
-          done(new Error('Should not success'));
-        },
-        error: function(err) {
-          expect(err.code).to.be.equal(206);
-          done();
-        }
+    it('User#save without token', function() {
+      return user.save({username: username + 'changed'}).then(function() {
+        throw new Error('Should not success');
+      }, function(err) {
+        expect(err.code).to.be.equal(206);
       });
     });
 
-    it('User#save with token', function(done) {
-      user.save({username: username + 'changed'}, {
-        sessionToken: user.getSessionToken(),
-        success: function() {
-          done();
-        },
-        error: function(err) {
-          done(err);
-        }
+    it('User#save with token', function() {
+      return user.save({
+        username: username + 'changed'
+      }, {sessionToken: user.getSessionToken()}).then(function() {
+        user.fetch().then(function() {
+          expect(user.username).to.be.equal(username + 'changed');
+        });
       });
     });
 


### PR DESCRIPTION
https://github.com/leancloud/leanengine-node-sdk/issues/38

## 禁用 currentUser

* [x] 实现 AVUser.disableCurrentUser.
* [x] 添加AVUser#getSessionToken 获取 Session Token.
* [x] 在 AVUser 实例上添加 logOut 方法，代替 AVUser 上的同名类方法。
* [x] signUp, logIn, fetch, become 等方法不再写入 currentUser.
* [x] AVUser.current 和 AVUser.currentAsync 打印警告并返回空结果。

## 支持自行指定 sessionToken

* [x] 为 AV._request() 添加一个 sessionToken 参数
* [x] 在启用 disableCurrentUser 时不发送 installationId
* [x] 为 Object, Query, Cloud, File, Insight, JobQuery, Push, SearchQuery, Status, User 模块的网络操作添加 sessionToken 参数

## 测试

* [x] 在浏览器和 Node.js 运行未开启 disableCurrentUser 的测试（不应对现有行为产生影响）
* [x] 在 Node.js 测试开启 disableCurrentUser 时上述行为的正确性
* [x] 在 Node.js 测试开启 disableCurrentUser 时不应影响其他无关部分的行为