### PR TITLE
Fixed decoding pointer type.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -564,7 +564,7 @@ module.exports = function(AV) {
     if (value.__type === "Pointer") {
       className = value.className;
       var pointer = AV.Object._create(className);
-      if(value.createdAt){
+      if(Object.keys(value).length > 3) {
           delete value.__type;
           delete value.className;
           pointer._finishFetch(value, true);


### PR DESCRIPTION
原来的判断不够严谨，因为用户可能将 createdAt 设置为隐藏。
因此更安全的判断是认为返回的 json object value 的 keys 大于3个（className,__type, objectId)。


