### PR TITLE
修正 ajax.js 在错误情况下返回值格式不正确的错误

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -147,7 +147,7 @@ gulp.task('compress-docs', ['docs'], () => {
 });
 
 // Istanbul unit test coverage plugin for gulp.
-gulp.task('instrument', () => {
+gulp.task('instrument', ['release'], () => {
   return gulp.src(['dist/node/**/*.js'])
     .pipe(istanbul())
     .pipe(istanbul.hookRequire());

--- a/src/browserify-wrapper/ajax.js
+++ b/src/browserify-wrapper/ajax.js
@@ -53,7 +53,7 @@ module.exports = function _ajax(method, resourceUrl, data, success, error) {
           promise.reject(err);
         }
       } else {
-        promise.reject(JSON.parse(responseText));
+        promise.reject({responseText: responseText});
       }
     });
   });

--- a/test/user.js
+++ b/test/user.js
@@ -68,6 +68,16 @@ describe("User", function() {
       });
 
     });
+
+    it("should fail with wrong password", function() {
+      return AV.User.logIn(username, 'wrong password').then(function() {
+        throw new Error('Should not success');
+      }, function(err) {
+        expect(err.code).to.be.equal(210);
+        expect(err.message).to.be.equal('The username and password mismatch.');
+      });
+    });
+
   });
 
 


### PR DESCRIPTION
[AV._request](https://github.com/leancloud/javascript-sdk/blob/master/lib/utils.js#L348) 中是期待错误情况下返回一个具有 responseText 属性的 xhr 对象的，但 ajax.js 里却返回了 `JSON.parse(responseText)`，这个错误会导致当请求出错时无法显示正确的错误提示。

之前的测试并没有覆盖这一点，因此我给 User.logIn 加了一个失败情况的测试来覆盖。