### PR TITLE
_ajax 暴露一个属性用于自定义 User Agent（Node.js 环境）

### DIFF
--- a/src/browserify-wrapper/ajax.js
+++ b/src/browserify-wrapper/ajax.js
@@ -44,7 +44,7 @@ module.exports = function _ajax(method, resourceUrl, data, success, error) {
     agent: transportAgent,
     headers: {
       'Content-Type': 'text/plain',
-      'User-Agent': 'AV/' + VERSION + ' (Node.js' + process.version + ')'
+      'User-Agent': _ajax.userAgent || 'AV/' + VERSION + '; Node.js/' + process.version
     }
   });
 


### PR DESCRIPTION
使用方法：`AV._ajax.userAgent = 'AV/js1.0.0-rc8; Node.js/v4.1.2';`

顺便又调整了一下默认的 User Agent 为符合 HTTP 标准的格式 `AV/js1.0.0-rc8; Node.js/v4.1.2`，因为目前这个 User Agent 还没被实际用到，所以这个修改不会产生影响。

#251 