### PR TITLE
fix(Object.fetch): options 默认为空对象、允许 include 选项为数组

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -795,13 +795,17 @@ module.exports = function(AV) {
      *     completes.
      */
     fetch: function() {
-      var options = null;
+      var options = {};
       var fetchOptions = {};
       if(arguments.length === 1) {
         options = arguments[0];
       } else if(arguments.length === 2) {
         fetchOptions = arguments[0];
-        options = arguments[1];
+        options = arguments[1] || {};
+      }
+
+      if (fetchOptions && fetchOptions.include && fetchOptions.include.length > 0) {
+        fetchOptions.include = fetchOptions.include.join(',');
       }
 
       var self = this;

--- a/test/object.js
+++ b/test/object.js
@@ -350,6 +350,19 @@ describe('Objects', function(){
       });
     });
 
+    it('should fetch include authors successfully', function() {
+      var myPost = new Post();
+      myPost.set('author1', new Person({name: '1'}));
+      myPost.set('author2', new Person({name: '2'}));
+      return myPost.save().then(function() {
+        myPost = AV.Object.createWithoutData('Post', myPost.id);
+        return myPost.fetch({include: ['author1', 'author2']}, {}).then(function() {
+          expect(myPost.get('author1').get('name')).to.be('1');
+          expect(myPost.get('author2').get('name')).to.be('2');
+        });
+      });
+    });
+
     /*
 
        it("it should fetch relation post",function(done){


### PR DESCRIPTION
@wujun4code 

修复两个 Bug:

1. `object.fetch()` 会有 `read sessionToken from undefined` 的错误

2. include 选项不支持传递一个数组，这个行为和 `AV.Query` 以及其他 SDK 都不一致。这个问题在 rc8 存在，但因为这两天网络请求模块的修改，当前 master 的代码又不会有这个问题了（从 GET 请求改成了 POST 请求），但保险起见还是加了对数组的序列化处理。