### PR TITLE
有关 disable-current-user 的若干优化

### DIFF
--- a/src/cloudfunction.js
+++ b/src/cloudfunction.js
@@ -52,7 +52,8 @@ module.exports = function(AV) {
           ._thenRunCallbacks(options);
       }
 
-      return AVRequest('call', name, null, 'POST', AV._encodeObjectOrArray(data)).then(function(resp) {
+      return AVRequest('call', name, null, 'POST', AV._encodeObjectOrArray(data),
+                       options && options.sessionToken).then(function(resp) {
         return AV._decode('', resp).result;
       })._thenRunCallbacks(options);
     },

--- a/src/file.js
+++ b/src/file.js
@@ -351,7 +351,7 @@ module.exports = function(AV) {
     let owner;
     if (data && data.owner) {
       owner = data.owner;
-    } else {
+    } else if (!AV._config.disableCurrentUser) {
       try {
         owner = AV.User.current();
       } catch (e) {

--- a/src/user.js
+++ b/src/user.js
@@ -7,8 +7,6 @@ const _ = require('underscore');
 const AVError = require('./error');
 const AVRequest = require('./request').request;
 
-let disableCurrentUserWarning = false;
-
 module.exports = function(AV) {
   /**
    * @class
@@ -798,10 +796,7 @@ module.exports = function(AV) {
      */
     logOut: function() {
       if (AV._config.disableCurrentUser) {
-        if (!disableCurrentUserWarning) {
-          console.trace('AV.User.current() was disabled in multi-user environment, call logOut() from user object instead https://leancloud.cn/docs/leanengine-node-sdk-upgrade-1.html');
-          disableCurrentUserWarning = true;
-        }
+        console.warn('AV.User.current() was disabled in multi-user environment, call logOut() from user object instead https://leancloud.cn/docs/leanengine-node-sdk-upgrade-1.html');
         return AV.Promise.as(null);
       }
 
@@ -983,10 +978,7 @@ module.exports = function(AV) {
      */
     currentAsync: function() {
       if (AV._config.disableCurrentUser) {
-        if (!disableCurrentUserWarning) {
-          console.trace('AV.User.currentAsync() was disabled in multi-user environment, access user from request instead https://leancloud.cn/docs/leanengine-node-sdk-upgrade-1.html');
-          disableCurrentUserWarning = true;
-        }
+        console.warn('AV.User.currentAsync() was disabled in multi-user environment, access user from request instead https://leancloud.cn/docs/leanengine-node-sdk-upgrade-1.html');
         return AV.Promise.as(null);
       }
 
@@ -1035,10 +1027,7 @@ module.exports = function(AV) {
      */
     current: function() {
       if (AV._config.disableCurrentUser) {
-        if (!disableCurrentUserWarning) {
-          console.trace('AV.User.current() was disabled in multi-user environment, access user from request instead https://leancloud.cn/docs/leanengine-node-sdk-upgrade-1.html');
-          disableCurrentUserWarning = true;
-        }
+        console.warn('AV.User.current() was disabled in multi-user environment, access user from request instead https://leancloud.cn/docs/leanengine-node-sdk-upgrade-1.html');
         return null;
       }
 


### PR DESCRIPTION
* AV.Cloud.rpc 方法也需支持 sessionToken 参数，之前是因为 PR 合并顺序的缘故落下了这个函数。
* disableCurrentUser 的情况下，AV.User.logOut 应该返回一个空的 Promise 而不是 return console.warn();
* disableCurrentUser 相关的警告只打印一次，以免日志打印过多；并用 console.trace() 打印调用栈，方便找到调用处。

https://github.com/leancloud/javascript-sdk/issues/251