### PR TITLE
fix(AV): use global AV if exists

### DIFF
--- a/src/av.js
+++ b/src/av.js
@@ -11,7 +11,7 @@
  * Each engineer has a duty to keep the code elegant
 **/
 
-const AV = module.exports = {};
+const AV = module.exports = global.AV || {};
 AV._ = require('underscore');
 AV.version = require('./version');
 AV.Promise = require('./promise');


### PR DESCRIPTION
 #274 use browserify's UMD wrapper, which overrides predefined global AV.