### PR TITLE
fix: prevent getServerURLPromise from being resolved more then once

### DIFF
--- a/src/promise.js
+++ b/src/promise.js
@@ -312,8 +312,8 @@ _.extend(Promise.prototype, /** @lends AV.Promise.prototype */ {
    */
   resolve: function(result) {
     if (this._resolved || this._rejected) {
-      throw "A promise was resolved even though it had already been " +
-        (this._resolved ? "resolved" : "rejected") + ".";
+      throw new Error("A promise was resolved even though it had already been " +
+        (this._resolved ? "resolved" : "rejected") + ".");
     }
     this._resolved = true;
     this._result = arguments;
@@ -352,8 +352,8 @@ _.extend(Promise.prototype, /** @lends AV.Promise.prototype */ {
    */
   reject: function(error) {
     if (this._resolved || this._rejected) {
-      throw "A promise was rejected even though it had already been " +
-        (this._resolved ? "resolved" : "rejected") + ".";
+      throw new Promise("A promise was rejected even though it had already been " +
+        (this._resolved ? "resolved" : "rejected") + ".");
     }
     this._rejected = true;
     this._error = error;

--- a/src/request.js
+++ b/src/request.js
@@ -12,7 +12,7 @@ const AVError = require('./error');
 const AV = require('./av');
 const _ = require('underscore');
 
-const getServerURLPromise = new AVPromise();
+let getServerURLPromise;
 
 // 服务器请求的节点 host
 const API_HOST = {
@@ -251,6 +251,7 @@ const refreshServerUrlByRouter = () => {
 };
 
 const setServerUrlByRegion = (region = 'cn') => {
+  getServerURLPromise = new AVPromise();
   // 如果用户在 init 之前设置了 APIServerURL，则跳过请求 router
   if (AV._config.APIServerURL) {
     getServerURLPromise.resolve();
@@ -294,6 +295,9 @@ const AVRequest = (route, className, objectId, method, dataObject = {}, sessionT
 
   checkRouter(route);
 
+  if (!getServerURLPromise) {
+    return AVPromise.error(new Error('Not initialized'));
+  }
   return getServerURLPromise.then(() => {
     const apiURL = createApiUrl(route, className, objectId, method, dataObject);
     return setHeaders(sessionToken).then(


### PR DESCRIPTION
fix `A promise was resolved even though it had already been resolved.` error when `AV.init` called more then once.