### PR TITLE
fix(package): support React Native v0.32

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
     "./dist/node/browserify-wrapper/localStorage.js": "./dist/node/browserify-wrapper/localstorage-browser.js",
     "./dist/node/browserify-wrapper/parse-base64.js": "./dist/node/browserify-wrapper/parse-base64-browser.js"
   },
+  "react-native": {
+    "react-native": "react-native"
+  },
   "eslintConfig": {
     "env": {
       "es6": true,


### PR DESCRIPTION
RN start to support false value for package.browser package redirection.
Add "react-native" field to resort react-native dependency while packed for RN.

fix #342.