### PR TITLE
Improve http request log

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -4,7 +4,7 @@
 **/
 
 const request = require('superagent');
-const debug = require('debug')('request');
+const debug = require('debug')('leancloud:request');
 const md5 = require('md5');
 const AVPromise = require('./promise');
 const Cache = require('./cache');
@@ -71,8 +71,12 @@ const checkRouter = (router) => {
   }
 };
 
+let requestsCount = 0;
+
 const ajax = (method, resourceUrl, data, headers = {}, onprogress) => {
-  debug(method, resourceUrl, data, headers);
+  const count = requestsCount++;
+
+  debug(`request(${count})`, method, resourceUrl, data, headers);
 
   const promise = new AVPromise();
   const req = request(method, resourceUrl)
@@ -80,7 +84,7 @@ const ajax = (method, resourceUrl, data, headers = {}, onprogress) => {
     .send(data)
     .end((err, res) => {
       if (res) {
-        debug(res.status, res.body, res.text);
+        debug(`response(${count})`, res.status, res.body && res.text, res.header);
       }
       if (err) {
         if (res) {


### PR DESCRIPTION
云引擎本地调试开启方法：`env DEBUG=leancloud:request lean up`。

* 调试的命名空间从 `request` 改为 `leancloud:request`，官方推荐用产品名加模块名来做命名空间。
* 添加一个计数器，否则在有并发请求的情况下无法区分哪个请求对应哪个响应（https://github.com/leancloud/javascript-sdk/issues/308 ）。我也想过在收到响应后再打印请求，但这样的话在请求超时的情况下就表现不是很好了，计数器还是最简单的解决方案。
* 响应也打印 headers，仅在 body 为空时打印 text.

这个功能主要还是为云引擎应用设计的，因为在浏览器里本来就可以用开发人员工具看到请求，这个 PR 合并后我会把这个说明补充到文档上，相信会给调试带来一些方便（尤其是我们向用户询问请求内容时）。