### PR TITLE
fix AV.Object.extend SO error and support ES6 extends syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "eslint-plugin-import": "^1.6.0",
     "eslint-plugin-jsx-a11y": "^1.0.3",
     "eslint-plugin-react": "^5.0.1",
-    "expect.js": "0.2.0",
+    "expect.js": "^0.3.0",
     "gulp": "^3.8.10",
     "gulp-babel": "^6.1.1",
     "gulp-clean": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "gulp-sourcemaps": "^1.6.0",
     "gulp-tar": "^1.3.2",
     "gulp-uglify": "^1.0.2",
-    "mocha": "2.4.5",
+    "mocha": "^3.0.0",
     "vinyl-source-stream": "^1.1.0"
   },
   "license": "MIT",

--- a/src/object.js
+++ b/src/object.js
@@ -1422,7 +1422,11 @@ module.exports = function(AV) {
       // This new subclass has been told to extend both from "this" and from
       // OldClassObject. This is multiple inheritance, which isn't supported.
       // For now, let's just pick one.
-      NewClassObject = OldClassObject._extend(protoProps, classProps);
+      if (protoProps || classProps) {
+        NewClassObject = OldClassObject._extend(protoProps, classProps);
+      } else {
+        return OldClassObject;
+      }
     } else {
       protoProps = protoProps || {};
       protoProps.className = className;
@@ -1442,7 +1446,7 @@ module.exports = function(AV) {
     AV.Object._classMap[className] = NewClassObject;
     return NewClassObject;
   };
-
+  
   AV.Object._findUnsavedChildren = function(object, children, files) {
     AV._traverse(object, function(object) {
       if (object instanceof AV.Object) {

--- a/src/object.js
+++ b/src/object.js
@@ -1429,7 +1429,7 @@ module.exports = function(AV) {
       }
     } else {
       protoProps = protoProps || {};
-      protoProps.className = className;
+      protoProps._className = className;
       NewClassObject = this._extend(protoProps, classProps);
     }
     // Extending a subclass should reuse the classname automatically.
@@ -1445,6 +1445,29 @@ module.exports = function(AV) {
     };
     AV.Object._classMap[className] = NewClassObject;
     return NewClassObject;
+  };
+
+  // ES6 class syntax support
+  Object.defineProperty(AV.Object.prototype, 'className', {
+    get: function(){
+      const className = this._className || this.constructor.name;
+      // If someone tries to subclass "User", coerce it to the right type.
+      if (className === "User") {
+        return "_User";
+      }
+      return className;
+    },
+  });
+
+  AV.Object.register = klass => {
+    if (!(klass.prototype instanceof AV.Object)) {
+      throw new Error('registered class is not a subclass of AV.Object');
+    }
+    const className = klass.name;
+    if (!className.length) {
+      throw new Error('registered class must be named');
+    }
+    AV.Object._classMap[className] = klass;
   };
   
   AV.Object._findUnsavedChildren = function(object, children, files) {

--- a/test/object.js
+++ b/test/object.js
@@ -4,6 +4,10 @@ var GameScore = AV.Object.extend("GameScore");
 
 var Post=AV.Object.extend("Post");
 
+// for #extend test
+class Person extends AV.Object {}
+var BackbonePerson = AV.Object.extend('Person');
+
 describe('Objects', function(){
   var objId;
   var gameScore = GameScore.new();
@@ -32,6 +36,23 @@ describe('Objects', function(){
       }
       new Test();
     });
+
+    it('ES6 extend syntex', () => {
+      var backbonePerson = new BackbonePerson();
+      backbonePerson.set('name', 'leeyeh');
+      var es6Person = new Person();
+      es6Person.set('name', 'leeyeh');
+      expect(backbonePerson.toJSON()).to.eql(es6Person.toJSON());
+      expect(backbonePerson._toFullJSON()).to.eql(es6Person._toFullJSON());
+    });
+
+    it('#resiger an ES6 class', () => {
+      expect(new AV.Object('Person')).to.be.a(BackbonePerson);
+      AV.Object.register(Person);
+      expect(new AV.Object('Person')).to.be.a(Person);
+      expect(() => AV.Object.register(1)).to.throwError();
+      expect(() => AV.Object.register(function(){})).to.throwError();
+    })
   });
 
   describe('#Saving Objects', function(){

--- a/test/object.js
+++ b/test/object.js
@@ -23,6 +23,17 @@ describe('Objects', function(){
     });
     new Post().name;
   });
+
+  describe('#extend', () => {
+    it('extend for multiple times should not throw', () => {
+      let Test;
+      for (var i=100000; i > 0; i--) {
+        Test = AV.Object.extend('Test');
+      }
+      new Test();
+    });
+  });
+
   describe('#Saving Objects', function(){
     it('should crate a Object', function(done){
       //gameScore.set("newcol","sss")
@@ -469,50 +480,10 @@ describe('Objects', function(){
         });
       });
     });
-
-    /*
-
-       it("it should fetch relation post",function(done){
-       var post=myComment.get("parent");
-       post.fetch({
-       success:function(post){
-       done();
-       }
-       })
-       })
-
-       it("many to many relations create",function(done){
-       var user = AV.User.current();
-       relation = user.relation("likes");
-       relation.add(post);
-       user.save({
-       success:function(){
-       done();
-       },
-       error:function(err){
-       throw err;
-       }
-       });
-       })
-
-       it("many to many relations query",function(done){
-
-       relation.query().find({
-       success: function(list) {
-       done();
-// list contains the posts that the current user likes.
-},
-error:function(err){
-throw err;
-}
-});
-})
-
-*/
+    
 
 
-});
-
+  });
 
 
 });//END  RETRIEVING

--- a/test/object.js
+++ b/test/object.js
@@ -206,7 +206,7 @@ describe('Objects', function(){
         expect(score2.id).to.be.eql(gameScore.id);
       })
     );
-    it('fetchAll with non-existed Class should fail', (done) => 
+    it('fetchAll with non-existed Class should fail', (done) => {
       AV.Object.fetchAll([
         AV.Object.createWithoutData('GameScore', gameScore.id),
         AV.Object.createWithoutData('FakeClass', gameScore.id),
@@ -216,8 +216,8 @@ describe('Objects', function(){
         expect(err).to.be.an(Error);
         done();
       })
-    );
-    it('fetchAll with dirty objet should fail', (done) => 
+    });
+    it('fetchAll with dirty objet should fail', (done) => {
       AV.Object.fetchAll([
         AV.Object.createWithoutData('GameScore', gameScore.id),
         new GameScore(),
@@ -227,7 +227,7 @@ describe('Objects', function(){
         expect(err).to.be.an(Error);
         done();
       })
-    );
+    });
   });
 
   describe("Deleting Objects",function(){

--- a/test/test.html
+++ b/test/test.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
     <script src="../node_modules/mocha/mocha.js"></script>
-    <script src="../node_modules/expect.js/expect.js"></script>
+    <script src="../node_modules/expect.js/index.js"></script>
     <script src="../node_modules/superagent/superagent.js"></script>
     <!--AV Test init-->
 

--- a/test/test.html
+++ b/test/test.html
@@ -22,7 +22,6 @@
         console.log(arguments);
       }
     </script>
-	<script src="promise.js"></script>
   <script src="storage.js"></script>
   <script src="cache.js"></script>
 	<script src="file.js"></script>
@@ -37,6 +36,7 @@
 	<script src="sms.js"></script>
 	<script src="search.js"></script>
 	<script src="cloud.js"></script>
+	<script src="promise.js"></script>
     <script>
       onload = function(){
       mocha.checkLeaks();


### PR DESCRIPTION
- 当调用 `AV.Object.extend` 只传一个参数时，直接返回已有的 class。
- 支持 ES6 的 extends 语法。由于 Class 声明没法自动注册，增加了 `AV.Object.register(Klass)` 方法用于注册。

close #331 close #337 