### PR TITLE
AVObject#ignoreHook, disableBeforeHook, disableAfterHook

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -1052,7 +1052,7 @@ module.exports = function(AV) {
       }
 
       var request =
-          AVRequest('classes', this.className, this.id, 'DELETE', null, options.sessionToken);
+          AVRequest('classes', this.className, this.id, 'DELETE', this._flags, options.sessionToken);
       return request.then(function() {
         if (options.wait) {
           triggerDestroy();
@@ -1595,6 +1595,7 @@ module.exports = function(AV) {
           return AVRequest("batch", null, null, "POST", {
             requests: _.map(batch, function(object) {
               var json = object._getSaveJSON();
+              _.extend(json, object._flags);
               var method = "POST";
 
               var path = "/1.1/classes/" + object.className;

--- a/src/object.js
+++ b/src/object.js
@@ -1278,6 +1278,18 @@ module.exports = function(AV) {
       return this.set("ACL", acl, options);
     },
 
+    disableBeforeHook: function() {
+      this.ignoreHook('beforeSave');
+      this.ignoreHook('beforeUpdate');
+      this.ignoreHook('beforeDelete');
+    },
+
+    disableAfterHook: function() {
+      this.ignoreHook('afterSave');
+      this.ignoreHook('afterUpdate');
+      this.ignoreHook('afterDelete');
+    },
+
     ignoreHook: function(hookName) {
       if (!_.contains(['beforeSave', 'afterSave', 'beforeUpdate', 'afterUpdate', 'beforeDelete', 'afterDelete'], hookName)) {
         console.trace('Unsupported hookName: ' + hookName);

--- a/src/object.js
+++ b/src/object.js
@@ -1295,8 +1295,8 @@ module.exports = function(AV) {
         console.trace('Unsupported hookName: ' + hookName);
       }
 
-      if (!AV.masterKey || !AV._useMasterKey) {
-        console.trace('ignoreHook required masterKey');
+      if (!AV.hookKey) {
+        console.trace('ignoreHook required hookKey');
       }
 
       if (!this._flags.__ignore_hooks) {

--- a/src/object.js
+++ b/src/object.js
@@ -59,6 +59,7 @@ module.exports = function(AV) {
 
     this._serverData = {};  // The last known data for this object from cloud.
     this._opSetQueue = [{}];  // List of sets of changes to the data.
+    this._flags = {};
     this.attributes = {};  // The best estimate of this's current data.
 
     this._hashedJSON = {};  // Hash of values of containers at last save.
@@ -990,6 +991,8 @@ module.exports = function(AV) {
           }
         }
 
+        _.extend(json, model._flags);
+
         var route = "classes";
         var className = model.className;
         if (model.className === "_User" && !model.id) {
@@ -1273,8 +1276,23 @@ module.exports = function(AV) {
      */
     setACL: function(acl, options) {
       return this.set("ACL", acl, options);
-    }
+    },
 
+    ignoreHook: function(hookName) {
+      if (!_.contains(['beforeSave', 'afterSave', 'beforeUpdate', 'afterUpdate', 'beforeDelete', 'afterDelete'], hookName)) {
+        console.trace('Unsupported hookName: ' + hookName);
+      }
+
+      if (!AV.masterKey || !AV._useMasterKey) {
+        console.trace('ignoreHook required masterKey');
+      }
+
+      if (!this._flags.__ignore_hooks) {
+        this._flags.__ignore_hooks = [];
+      }
+
+      this._flags.__ignore_hooks.push(hookName);
+    }
   });
 
    /**

--- a/src/request.js
+++ b/src/request.js
@@ -120,6 +120,9 @@ const setHeaders = (sessionToken, signKey) => {
       headers['X-LC-Key'] = AV.applicationKey;
     }
   }
+  if (AV.hookKey) {
+    headers['X-LC-Hook-Key'] = AV.hookKey;
+  }
   if (AV._config.applicationProduction !== null) {
     headers['X-LC-Prod'] = AV._config.applicationProduction;
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -115,13 +115,14 @@ const init = (AV) => {
    * @param {String} applicationId Your AV Application ID.
    * @param {String} applicationKey Your AV Application Key
    */
-  const initialize = (appId, appKey, masterKey) => {
+  const initialize = (appId, appKey, masterKey, hookKey) => {
     if (AV.applicationId && appId !== AV.applicationId && appKey !== AV.applicationKey && masterKey !== AV.masterKey) {
       console.warn('LeanCloud SDK is already initialized, please do not reinitialize it.');
     }
     AV.applicationId = appId;
     AV.applicationKey = appKey;
     AV.masterKey = masterKey;
+    AV.hookKey = hookKey || (AVConfig.isNode && process.env.LEANCLOUD_APP_HOOK_KEY);
     AV._useMasterKey = false;
   };
 
@@ -149,7 +150,7 @@ const init = (AV) => {
           if (!AVConfig.isNode && options.masterKey) {
             masterKeyWarn();
           }
-          initialize(options.appId, options.appKey, options.masterKey);
+          initialize(options.appId, options.appKey, options.masterKey, options.hookKey);
           request.setServerUrlByRegion(options.region);
           AVConfig.disableCurrentUser = options.disableCurrentUser;
         } else {

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -1,0 +1,198 @@
+var AV = require('..');
+var expect = require('expect.js');
+
+var IgnoreHookTest = AV.Object.extend('IgnoreHookTest');
+
+describe('hooks', function() {
+  it('Object#save (new object)', function() {
+    var object = new IgnoreHookTest();
+    object.set('title', 'test');
+    return object.save().then(function() {
+      return object.fetch(function(object) {
+        expect(object.get('byBeforeSave')).to.be.ok();
+        expect(object.get('byAfterSave')).to.be.ok();
+      });
+    });
+  });
+
+  it('Object#save (new object) disableBeforeHook', function() {
+    var object = new IgnoreHookTest();
+    object.set('title', 'test');
+    object.disableBeforeHook();
+    return object.save().then(function() {
+      return object.fetch(function(object) {
+        expect(object.get('byBeforeSave')).to.not.be.ok();
+        expect(object.get('byAfterSave')).to.be.ok();
+      });
+    });
+  });
+
+  it('Object#save (new object) ignore afterSave', function() {
+    var object = new IgnoreHookTest();
+    object.set('title', 'test');
+    object.ignoreHook('afterSave');
+    return object.save().then(function() {
+      return object.fetch(function(object) {
+        expect(object.get('byBeforeSave')).to.be.ok();
+        expect(object.get('byAfterSave')).to.not.be.ok();
+      });
+    });
+  });
+
+  it('Object#save (update object)', function() {
+    var object = new IgnoreHookTest();
+    object.set('title', 'test');
+    return object.save().then(function() {
+      object.set('title', 'something')
+      return object.save().then(function() {
+        return object.fetch(function(object) {
+          expect(object.get('byBeforeSave')).to.be.ok();
+          expect(object.get('byAfterSave')).to.be.ok();
+          expect(object.get('byBeforeUpdate')).to.be.ok();
+          expect(object.get('byAfterUpdate')).to.be.ok();
+        });
+      });
+    });
+  });
+
+  it('Object#save (update object) disableAfterHook', function() {
+    var object = new IgnoreHookTest();
+    object.set('title', 'test');
+    return object.save().then(function() {
+      object.set('title', 'something');
+      object.disableAfterHook();
+      return object.save().then(function() {
+        return object.fetch(function(object) {
+          expect(object.get('byBeforeSave')).to.be.ok();
+          expect(object.get('byAfterSave')).to.be.ok();
+          expect(object.get('byBeforeUpdate')).to.be.ok();
+          expect(object.get('byAfterUpdate')).to.not.be.ok();
+        });
+      });
+    });
+  });
+
+  it('Object#save (modify children)', function() {
+    var object = new IgnoreHookTest();
+    var child1 = new IgnoreHookTest();
+    var child2 = new IgnoreHookTest();
+    child1.set('title', 'test');
+    child1.disableBeforeHook();
+    object.set('child1', child1);
+    object.disableAfterHook();
+    return object.save().then(function() {
+      return object.fetch(function(object) {
+        expect(object.get('byBeforeSave')).to.be.ok();
+        expect(object.get('byAfterSave')).to.not.be.ok();
+      }).then(function() {
+        return child1.fetch(function(child1) {
+          expect(child1.get('byBeforeSave')).to.not.be.ok();
+          expect(child1.get('byAfterSave')).to.be.ok();
+        });
+      }).then(function() {
+        child1.set('title', 'something');
+        object.set('child1', child1);
+        child2.set('title', 'test');
+        child2.disableAfterHook();
+        object.set('child2', child2);
+        return object.save().then(function() {
+          object.fetch(function(object) {
+            expect(object.get('byBeforeUpdate')).to.be.ok();
+            expect(object.get('byAfterUpdate')).to.not.be.ok();
+          });
+        });
+      }).then(function() {
+        child1.fetch().then(function(child1) {
+          expect(child1.get('byBeforeUpdate')).to.not.be.ok();
+          expect(child1.get('byAfterUpdate')).to.be.ok();
+        });
+      }).then(function() {
+        child2.fetch().then(function(child2) {
+          expect(child2.get('byBeforeSave')).to.be.ok();
+          expect(child2.get('byAfterSave')).to.not.be.ok();
+        });
+      });
+    });
+  });
+
+  it('Object.saveAll', function() {
+    var object = new IgnoreHookTest();
+    var objectIgnoreBefore = new IgnoreHookTest();
+    var objectIgnoreAfter = new IgnoreHookTest();
+    var newObject = new IgnoreHookTest();
+    var newObjectIgnoreAll = new IgnoreHookTest();
+
+    return Promise.all([object, objectIgnoreBefore, objectIgnoreAfter].map(function(object) {
+      object.set('title', 'test');
+      return object.save();
+    })).then(function() {
+      newObjectIgnoreAll.disableBeforeHook();
+      newObjectIgnoreAll.disableAfterHook();
+
+      objectIgnoreBefore.disableBeforeHook();
+      objectIgnoreAfter.disableAfterHook();
+
+      var objects = [object, objectIgnoreBefore, objectIgnoreAfter, newObject, newObjectIgnoreAll];
+
+      objects.forEach(function(object) {
+        object.set('title', 'something');
+      });
+
+      return AV.Object.saveAll(objects).then(function(objects) {
+        return Promise.all(objects.map(function(object) {
+          return object.fetch();
+        })).then(function() {
+          expect(object.get('byBeforeSave')).to.be.ok();
+          expect(object.get('byAfterSave')).to.be.ok();
+          expect(object.get('byBeforeUpdate')).to.be.ok();
+          expect(object.get('byAfterUpdate')).to.be.ok();
+
+          expect(objectIgnoreBefore.get('byBeforeSave')).to.be.ok();
+          expect(objectIgnoreBefore.get('byAfterSave')).to.be.ok();
+          expect(objectIgnoreBefore.get('byBeforeUpdate')).to.not.be.ok();
+          expect(objectIgnoreBefore.get('byAfterUpdate')).to.be.ok();
+
+          expect(objectIgnoreAfter.get('byBeforeSave')).to.be.ok();
+          expect(objectIgnoreAfter.get('byAfterSave')).to.be.ok();
+          expect(objectIgnoreAfter.get('byBeforeUpdate')).to.be.ok();
+          expect(objectIgnoreAfter.get('byAfterUpdate')).to.not.be.ok();
+
+          expect(newObject.get('byBeforeSave')).to.be.ok();
+          expect(newObject.get('byAfterSave')).to.be.ok();
+          expect(newObject.get('byBeforeUpdate')).to.not.be.ok();
+          expect(newObject.get('byAfterUpdate')).to.not.be.ok();
+
+          expect(newObjectIgnoreAll.get('byBeforeSave')).to.not.be.ok();
+          expect(newObjectIgnoreAll.get('byAfterSave')).to.not.be.ok();
+          expect(newObjectIgnoreAll.get('byBeforeUpdate')).to.not.be.ok();
+          expect(newObjectIgnoreAll.get('byAfterUpdate')).to.not.be.ok();
+        });
+      });
+    });
+  });
+
+  it('Object#destroy', function() {
+    var object = new IgnoreHookTest();
+    object.set('title', 'test');
+    return object.save().then(function() {
+      object.set('title', 'something');
+      object.disableBeforeHook();
+      return object.destroy();
+    });
+  });
+
+  it('Object#destroyAll', function() {
+    var object = new IgnoreHookTest();
+    var objectIgnoreBefore = new IgnoreHookTest();
+    objectIgnoreBefore.disableBeforeHook();
+
+    return Promise.all([object, objectIgnoreBefore].map(function(object) {
+      return object.save();
+    })).then(function() {
+      return AV.Object.destroyAll([object, objectIgnoreBefore]);
+    }).then(function(result) {
+      expect(result[0].error).to.be.ok();
+      expect(result[1].error).to.not.be.ok();
+    });
+  });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -17,6 +17,7 @@ AV.init({
   appId: '95TNUaOSUd8IpKNW0RSqSEOm-9Nh9j0Va',
   appKey: 'gNAE1iHowdQvV7cqpfCMGaGN',
   masterKey: 'ue9M9nqwD4MQNXD3oiN5rAOv',
+  hookKey: '2iCbUZDgEF0siKxmCn2kVQXV'
 });
 AV.setProduction(true);
 AV._useMasterKey = true;


### PR DESCRIPTION
之前我们使用了一种签名机制（ https://github.com/leancloud/uluru-platform/issues/2242 ）来验证客户端是否有权限（由 masterKey 签名）跳过 Hook 以及客户端是否希望跳过 Hook（是否有一个 __before 或者 __after 字段）；这个签名也用于客户端验证 Hook 调用是否是由可信的来源发起，不过这和该 PR 无关。在新的机制中，是否有权跳过 Hook 是由请求是否是用 masterKey 发起的来确定的，而是否希望跳过 Hook 是通过一个 `__ignore_hooks` 的属性。

在客户端实现上，之前是在 Node SDK 里通过这样的 hack 来实现的：

```
obj.set('__before', sign);
```

这实际上是相当于对对象做了一次修改，也就导致了 https://github.com/leancloud/cloud-code/issues/960 的这个 Bug，因此希望把跳过 Hook 的功能直接做到 JavaScript SDK 里来避免 hack.



完成「服务器验证客户端是否有权限跳过 Hook」和「客户端验证 Hook 调用是否是由可信的来源发起的」两项工作；新的机制（ https://github.com/leancloud/uluru-platform/issues/2384 ）将会引入一个 Hook Key 的机制。

目前只实现了一个原型版本，还有很多问题需要考虑：

- [x] 继续沿用原 disableBeforeHook 和 disableAfterHook 的 API 还是改成一个单独的 ignoreHook（因为新的机制可以更细粒度地控制要跳过哪些 Hook）。 —— 保留现有的 disableBeforeHook() 和 disableAfterHook()，新增一个 ignoreHook(name) 。
- [x] 目前只考虑了 save 的情况，删除对象也需要考虑，删除对象目前是只发了 id 而没有发 body, 因此实际上是没有发送 __before 或 __after 的 https://forum.leancloud.cn/t/disablebeforehook-av-object-destroyall/11678 而且还要考虑 destroyAll 这种批量删除的情况 —— destroyAll 改为 batch 操作，在每个操作的 body 中发送 __ignore_hooks
- [x] 如何用户没有设置 AV._useMasterKey 怎么办？跳过 Hook 的请求是必须用 masterKey 发送的，而 Hook 请求中为了避免死循环又是必须跳过同类 Hook 的 —— 客户端发送 hookKey 而不是 masterKey 来表示要跳过 Hook。