### PR TITLE
fix(Object): add reserved keys, remove id alias

### DIFF
--- a/src/file.js
+++ b/src/file.js
@@ -456,7 +456,6 @@ module.exports = function(AV) {
     get: function(attrName) {
       switch (attrName) {
         case 'objectId':
-        case 'id':
           return this.id;
         case 'url':
         case 'name':

--- a/src/object.js
+++ b/src/object.js
@@ -3,6 +3,13 @@ const AVError = require('./error');
 const AVRequest = require('./request').request;
 const utils = require('./utils');
 
+const RESERVED_KEYS = ['objectId', 'createdAt', 'updatedAt'];
+const checkReservedKey = key => {
+  if (RESERVED_KEYS.indexOf(key) !== -1) {
+    throw new Error(`key[${key}] is reserved`);
+  }
+};
+
 // AV.Object is analogous to the Java AVObject.
 // It also implements the same interface as a Backbone model.
 
@@ -289,7 +296,6 @@ module.exports = function(AV) {
     get: function(attr) {
       switch (attr) {
         case 'objectId':
-        case 'id':
           return this.id;
         case 'createdAt':
         case 'updatedAt':
@@ -355,7 +361,7 @@ module.exports = function(AV) {
     _mergeMagicFields: function(attrs) {
       // Check for changes of magic fields.
       var model = this;
-      var specialFields = ["id", "objectId", "createdAt", "updatedAt"];
+      var specialFields = ["objectId", "createdAt", "updatedAt"];
       AV._arrayEach(specialFields, function(attr) {
         if (attrs[attr]) {
           if (attr === "objectId") {
@@ -363,8 +369,8 @@ module.exports = function(AV) {
           } else if ((attr === "createdAt" || attr === "updatedAt") &&
                      !_.isDate(attrs[attr])) {
             model[attr] = AV._parseDate(attrs[attr]);
-          } else {
-            model[attr] = attrs[attr];
+          } else { 
+            model[attr] = attrs[attr]; 
           }
           delete attrs[attr];
         }
@@ -604,11 +610,13 @@ module.exports = function(AV) {
       if (_.isObject(key) || utils.isNullOrUndefined(key)) {
         attrs = key;
         AV._objectEach(attrs, function(v, k) {
+          checkReservedKey(k);
           attrs[k] = AV._decode(k, v);
         });
         options = value;
       } else {
         attrs = {};
+        checkReservedKey(key);
         attrs[key] = AV._decode(key, value);
       }
 

--- a/test/object.js
+++ b/test/object.js
@@ -25,6 +25,19 @@ describe('Objects', function(){
     });
     new Post().name;
   });
+  
+  it('reserved keys', () => {
+    (() => new Person({
+      objectId: '0'
+    })).should.throwError(/reserved/);
+    (() => new Person({
+      createdAt: '0'
+    })).should.throwError(/reserved/);
+    (() => new Person({
+      updatedAt: '0'
+    })).should.throwError(/reserved/);
+    (() => new Person().set('objectId', '1')).should.throwError(/reserved/);
+  })
 
   describe('#extend', () => {
     it('extend for multiple times should not throw', () => {
@@ -69,6 +82,7 @@ describe('Objects', function(){
       gameScore.set("playerName", "dd");
       gameScore.set("cheatMode", false);
       gameScore.set("arr", ["arr1","arr2"]);
+      gameScore.set('id', 'id');
       return gameScore.save().then(function(result) {
         expect(result.id).to.be.ok();
         objId=result.id;
@@ -107,6 +121,7 @@ describe('Objects', function(){
       return query.get(objId).then(function(result) {
         expect(gameScore.id).to.be.ok();
         expect(gameScore.get('objectId')).to.be(gameScore.id);
+        expect(gameScore.get('id')).to.be('id');
       });
     });
   });


### PR DESCRIPTION
POTENTIALLY BREAKING:

before: object.get('id') //-> objectId
after: object.get('id') //-> id

before: object.set('objectId', 'xxx') // OK
after: object.set('objectId', 'xxx') // throw

https://github.com/leancloud/paas/issues/872
