### PR TITLE
属性删除错误

### DIFF
--- a/src/acl.js
+++ b/src/acl.js
@@ -83,7 +83,7 @@ module.exports = function(AV) {
     } else {
       delete permissions[accessType];
       if (_.isEmpty(permissions)) {
-        delete permissions[userId];
+        delete this.permissionsById[userId];
       }
     }
   };


### PR DESCRIPTION
如果`permissions`为空，应该删除 `this.permissionsById[userId]`