### PR TITLE
feat(Object): make toJSON result contains included pointers

### DIFF
--- a/src/file.js
+++ b/src/file.js
@@ -198,13 +198,13 @@ module.exports = function(AV) {
     return file;
   };
 
-  AV.File.prototype = {
+  _.extend(AV.File.prototype, /** @lends AV.File.prototype */ {
     className: '_File',
 
-    _toFullJSON(seenObjects) {
+    _toFullJSON(seenObjects, full = true) {
       var json = _.clone(this.attributes);
       AV._objectEach(json, function(val, key) {
-        json[key] = AV._encode(val, seenObjects);
+        json[key] = AV._encode(val, seenObjects, undefined, full);
       });
       AV._objectEach(this._operations, function(val, key) {
         json[key] = val;
@@ -219,17 +219,28 @@ module.exports = function(AV) {
           json[key] = _.isDate(val) ? val.toJSON() : val;
         }
       });
-      json.__type = "File";
+      if (full) {
+        json.__type = "File";
+      }
       return json;
     },
 
-    toJSON() {
-      const json = this._toFullJSON();
-      // add id and keep __type for backward compatible
-      if (_.has(this, 'id')) {
-        json.id = this.id;
-      }
-      return json;
+    /**
+     * Returns a JSON version of the file with meta data.
+     * Inverse to {@link AV.parseJSON}
+     * @since 2.0.0
+     * @return {Object}
+     */
+    toFullJSON(seenObjects = []) {
+      return this._toFullJSON(seenObjects);
+    },
+
+    /**
+     * Returns a JSON version of the object.
+     * @return {Object}
+     */
+    toJSON: function(key, holder, seenObjects = [this]) {
+      return this._toFullJSON(seenObjects, false);
     },
 
     /**
@@ -545,5 +556,5 @@ module.exports = function(AV) {
       _.extend(this, value);
       return this;
     }
-  };
+  });
 };

--- a/src/geopoint.js
+++ b/src/geopoint.js
@@ -107,7 +107,7 @@ module.exports = function(AV) {
     }, reject);
   });
 
-  AV.GeoPoint.prototype = {
+  _.extend(AV.GeoPoint.prototype, /** @lends AV.GeoPoint.prototype */ {
     /**
      * Returns a JSON representation of the GeoPoint, suitable for AV.
      * @return {Object}
@@ -161,5 +161,5 @@ module.exports = function(AV) {
     milesTo: function(point) {
       return this.radiansTo(point) * 3958.8;
     }
-  };
+  });
 };

--- a/src/insight.js
+++ b/src/insight.js
@@ -77,7 +77,7 @@ module.exports = function(AV) {
     this._limit = 100;
   };
 
-  AV.Insight.JobQuery.prototype = {
+  _.extend(AV.Insight.JobQuery.prototype, /** @lends AV.Insight.JobQuery.prototype */ {
 
     /**
      * Sets the number of results to skip before returning any results.
@@ -129,6 +129,6 @@ module.exports = function(AV) {
       });
     }
 
-  };
+  });
 
 };

--- a/src/op.js
+++ b/src/op.js
@@ -19,9 +19,9 @@ module.exports = function(AV) {
     this._initialize.apply(this, arguments);
   };
 
-  AV.Op.prototype = {
+  _.extend(AV.Op.prototype, /** @lends AV.Op.prototype */ {
     _initialize: function() {}
-  };
+  });
 
   _.extend(AV.Op, {
     /**

--- a/src/query.js
+++ b/src/query.js
@@ -166,7 +166,7 @@ module.exports = function(AV) {
 
   AV.Query._extend = AV._extend;
 
-  AV.Query.prototype = {
+  _.extend(AV.Query.prototype, /** @lends AV.Query.prototype */ {
      //hook to iterate result. Added by dennis<xzhuang@avoscloud.com>.
      _processResult: function(obj){
         return obj;
@@ -791,21 +791,21 @@ module.exports = function(AV) {
       return this;
     },
 
-  /**
-   * Also sorts the results in ascending order by the given key. The previous sort keys have
-   * precedence over this key.
-   *
-   * @param {String} key The key to order by
-   * @return {AV.Query} Returns the query so you can chain this call.
-   */
-   addAscending: function(key){
-     requires(key, 'undefined is not a valid key');
-     if(this._order)
-       this._order +=  ','  + key;
-    else
-       this._order = key;
-    return this;
-   },
+    /**
+     * Also sorts the results in ascending order by the given key. The previous sort keys have
+     * precedence over this key.
+     *
+     * @param {String} key The key to order by
+     * @return {AV.Query} Returns the query so you can chain this call.
+     */
+    addAscending: function(key){
+      requires(key, 'undefined is not a valid key');
+      if(this._order)
+        this._order +=  ','  + key;
+      else
+        this._order = key;
+      return this;
+    },
 
     /**
      * Sorts the results in descending order by the given key.
@@ -819,21 +819,21 @@ module.exports = function(AV) {
       return this;
     },
 
-     /**
-   * Also sorts the results in descending order by the given key. The previous sort keys have
-   * precedence over this key.
-   *
-   * @param {String} key The key to order by
-   * @return {AV.Query} Returns the query so you can chain this call.
-   */
-   addDescending: function(key){
-     requires(key, 'undefined is not a valid key');
-     if(this._order)
-       this._order += ',-' + key;
-     else
-       this._order = '-' + key;
-     return this;
-   },
+    /**
+     * Also sorts the results in descending order by the given key. The previous sort keys have
+     * precedence over this key.
+     *
+     * @param {String} key The key to order by
+     * @return {AV.Query} Returns the query so you can chain this call.
+     */
+    addDescending: function(key){
+      requires(key, 'undefined is not a valid key');
+      if(this._order)
+        this._order += ',-' + key;
+      else
+        this._order = '-' + key;
+      return this;
+    },
 
     /**
      * Add a proximity based constraint for finding objects with key point
@@ -996,7 +996,7 @@ module.exports = function(AV) {
         });
       });
     }
-  };
+  });
 
    AV.FriendShipQuery = AV.Query._extend({
      _objectClass: AV.User,

--- a/src/relation.js
+++ b/src/relation.js
@@ -38,7 +38,7 @@ module.exports = function(AV) {
     return query;
   };
 
-  AV.Relation.prototype = {
+  _.extend(AV.Relation.prototype, /** @lends AV.Relation.prototype */ {
     /**
      * Makes sure that this relation has the right parent and key.
      * @private
@@ -111,5 +111,5 @@ module.exports = function(AV) {
 
       return query;
     }
-  };
+  });
 };

--- a/src/search.js
+++ b/src/search.js
@@ -17,7 +17,7 @@ module.exports = function(AV) {
     this._sortFields = [];
   };
 
-  AV.SearchSortBuilder.prototype = {
+  _.extend(AV.SearchSortBuilder.prototype, /** @lends AV.SearchSortBuilder.prototype */ {
     _addField: function(key, order, mode, missing) {
       var field = {};
       field[key] = {
@@ -92,7 +92,7 @@ module.exports = function(AV) {
     build: function() {
       return JSON.stringify(AV._encode(this._sortFields));
     }
-  };
+  });
 
   /**
    * App searching query.Use just like AV.Query:

--- a/src/status.js
+++ b/src/status.js
@@ -29,7 +29,7 @@ module.exports = function(AV) {
     return this;
   };
 
-  AV.Status.prototype = {
+  _.extend(AV.Status.prototype, /** @lends AV.Status.prototype */ {
     /**
      * Gets the value of an attribute in status data.
      * @param {String} attr The string name of an attribute.
@@ -127,7 +127,7 @@ module.exports = function(AV) {
         delete serverData.updatedAt;
         this.data = AV._decode(serverData);
     }
-  };
+  });
 
   /**
    * Send a status to current signined user's followers.

--- a/test/file.js
+++ b/test/file.js
@@ -152,9 +152,8 @@ describe('File', function() {
       });
       it('decode and encode', function () {
         const json = this.file.toJSON();
-        // backward compatible check
-        json.should.have.properties(['__type', 'id', 'name', 'url']);
-        const file = AV._decode(json);
+        json.should.have.properties(['objectId', 'name', 'url']);
+        const file = AV._decode(this.file._toFullJSON());
         expect(file).to.be.a(AV.File);
         expect(file.id).to.be(fileId);
         expect(file.name()).to.be('myfile.txt');

--- a/test/object.js
+++ b/test/object.js
@@ -107,6 +107,158 @@ describe('Objects', function(){
       parsedGameScore.get('score').should.eql(gameScore.get('score'));
     });
 
+    it('toJSON for nested objects', () => {
+      const id = 'fakeObjectId';
+      const a = AV.Object.createWithoutData('A', id, true);
+      const b = AV.Object.createWithoutData('B', id, true);
+      const c = AV.Object.createWithoutData('C', id, true);
+      c.set('foo', 'bar');
+      c.set('a', a);
+      c.set('b', b);
+      b.set('c', c);
+      a.set('array', [b, c]);
+
+      a.toJSON().should.eql({
+        objectId: id,
+        array: [
+          {
+            objectId: id,
+            c: {
+              objectId: id,
+              foo: 'bar',
+              a: { __type: 'Pointer', className: 'A', objectId: id },
+              b: { __type: 'Pointer', className: 'B', objectId: id },
+            },
+          },
+          {
+            objectId: id,
+            foo: 'bar',
+            a: { __type: 'Pointer', className: 'A', objectId: id },
+            b: {
+              objectId: id,
+              c: { __type: 'Pointer', className: 'C', objectId: id },
+            },
+          },
+        ],
+      });
+
+      a.toFullJSON().should.eql({
+        __type: 'Object',
+        className: 'A',
+        objectId: id,
+        array: [
+          {
+            __type: 'Pointer',
+            className: 'B',
+            objectId: id,
+            c: {
+              __type: 'Pointer',
+              className: 'C',
+              objectId: id,
+              foo: 'bar',
+              a: { __type: 'Pointer', className: 'A', objectId: id },
+              b: { __type: 'Pointer', className: 'B', objectId: id },
+            },
+          },
+          {
+            __type: 'Pointer',
+            className: 'C',
+            objectId: id,
+            foo: 'bar',
+            a: { __type: 'Pointer', className: 'A', objectId: id },
+            b: {
+              __type: 'Pointer',
+              className: 'B',
+              objectId: id,
+              c: { __type: 'Pointer', className: 'C', objectId: id },
+            },
+          },
+        ],
+      });
+
+      const response = {
+        "__type":'Object',
+        "className":'A',
+        "foo": "bar",
+        "createdAt": "2017-02-15T14:08:39.892Z",
+        "updatedAt": "2017-02-20T07:31:57.808Z",
+        "b": {
+          "a": {
+            "foo": "bar",
+            "createdAt": "2017-02-15T14:08:39.892Z",
+            "updatedAt": "2017-02-20T07:31:57.808Z",
+            "b": {
+              "__type": "Pointer",
+              "className": "B",
+              "objectId": "58a461118d6d8100580a0c54"
+            },
+            "time": {
+              "__type": "Date",
+              "iso": "2011-11-11T03:11:11.000Z"
+            },
+            "file": {
+              "__type": "Pointer",
+              "className": "_File",
+              "objectId": "58a42299570c35006cdfdd5c"
+            },
+            "objectId": "58a460e78d6d810057e9f616",
+            "__type": "Pointer",
+            "className": "A"
+          },
+          "createdAt": "2017-02-15T14:09:21.965Z",
+          "updatedAt": "2017-02-15T14:09:21.965Z",
+          "objectId": "58a461118d6d8100580a0c54",
+          "__type": "Pointer",
+          "className": "B"
+        },
+        "time": {
+          "__type": "Date",
+          "iso": "2011-11-11T03:11:11.000Z"
+        },
+        "file": {
+          "mime_type": "image/jpeg",
+          "updatedAt": "2017-02-15T09:42:49.960Z",
+          "name": "file-name.jpg",
+          "objectId": "58a42299570c35006cdfdd5c",
+          "createdAt": "2017-02-15T09:42:49.960Z",
+          "__type": "File",
+          "url": "http://ac-rYAutyUJ.clouddn.com/9a403255e8e55d309d81.jpg",
+          "metaData": {
+            "owner": "589aeac3128fe10058fde344"
+          },
+          "bucket": "rYAutyUJ"
+        },
+        "inlineFile": {
+          "name": "README.md",
+          "url": "http://ac-rYAutyUJ.clouddn.com/c5e38dfc54ab3db0c051.md",
+          "mime_type": "application/octet-stream",
+          "bucket": "rYAutyUJ",
+          "metaData": {
+            "owner": "unknown",
+            "size": 3296
+          },
+          "objectId": "58aaac378d6d810058b790dd",
+          "createdAt": "2017-02-20T08:43:35.719Z",
+          "updatedAt": "2017-02-20T08:43:35.719Z",
+          "__type": "File"
+        },
+        "objectId": "58a460e78d6d810057e9f616"
+      };
+      
+      AV.parseJSON(response).toFullJSON().should.eql(response);
+      
+      // should be shallow for backward compatiblity
+      a._toFullJSON().should.eql({
+        __type: 'Object',
+        className: 'A',
+        objectId: id,
+        array: [
+          { __type: 'Pointer', className: 'B', objectId: id },
+          { __type: 'Pointer', className: 'C', objectId: id },
+        ],
+      });
+    });
+
     it('should create a User',function(){
       var User = AV.Object.extend("User");
       var u = new User();


### PR DESCRIPTION
背景：

- `AV.Object#toJSON`，`AV.Object#_toFullJSON`方法返回的 JSON 中是不包含 included Pointers 的内容的，需要用户自行遍历处理。
- `AV._decode` 调用的是 `AV.Object#_toFullJSON`，因为上面这个问题，所以目前没有办法对一个 AV.Object 进行完整的序列化与反序列化。此外这个方法理应是 internal 的。

为了解决这两个问题，在新版中，`AV.Object#toJSON` 的定位是输出对象的有效信息，可以传给视图层直接消费。新增 `AV.Object#toFullJSON`，定位为序列化方法，输出包括类型信息在内的所有信息，可以通过新增的 `AV.parseJSON` 方法（alias `AV._decode`）反序列化，可以用来实现对象的持久化。

在这个 PR 里，为了保持兼容性，保留了 `AV.Object#_toFullJSON` 及其默认的行为，但这个方法其实的作用是 `_toJSON` ，并且可以通过两个参数控制输出 JSON 的行为。

- `seenObjects`: if falesy，将 Pointer 输出 Pointer 类型，否则尽可能贪心的输出 included 的 Pointer 内容（直到遇到循环依赖）。
- `full`: 控制是否输出 `__type` 与 `className` 的 meta 信息。

新设计 (v2) 中的 API 是组合这两个参数的结果：

| |full: false|full: true|
----|----|----
seenObjects: fales|`#toJSON`(v1)|`#_toFullJSON` (default)
seenObjects: []|`#toJSON`(v2)|`#toFullJSON`(v2)

为了更形象的说明这些 API 的区别，考虑服务端返回的以下数据：

```json
{
  "b": {
    "__type": "Pointer",
    "className": "B",
    "foo": "bar",
    "createdAt": "2017-02-15T14:09:21.965Z",
    "updatedAt": "2017-02-15T14:09:21.965Z",
    "objectId": "58a461118d6d8100580a0c54"
  },
  "time": {
    "__type": "Date",
    "iso": "2011-11-11T03:11:11.000Z"
  },
  "objectId": "58a460e78d6d810057e9f616",
  "createdAt": "2017-02-15T14:08:39.892Z",
  "updatedAt": "2017-02-16T10:49:00.176Z"
}
```

decode 为 A 的实例 a 后，调用各个方法后得到的结果：

`toJSON()` (v1)
```diff
{
  "b": {
    "__type": "Pointer",
    "className": "B",
-   "foo": "bar",
-   "createdAt": "2017-02-15T14:09:21.965Z",
-   "updatedAt": "2017-02-15T14:09:21.965Z",
    "objectId": "58a461118d6d8100580a0c54"
  },
  "time": {
    "__type": "Date",
    "iso": "2011-11-11T03:11:11.000Z"
  },
  "objectId": "58a460e78d6d810057e9f616",
  "createdAt": "2017-02-15T14:08:39.892Z",
  "updatedAt": "2017-02-16T10:49:00.176Z"
}
```

`_toFullJSON` (v1,v2)
```diff
{
+ "__type": "Object",
+ "className": "A",
  "b": {
    "__type": "Pointer",
    "className": "B",
-   "foo": "bar",
-   "createdAt": "2017-02-15T14:09:21.965Z",
-   "updatedAt": "2017-02-15T14:09:21.965Z",
    "objectId": "58a461118d6d8100580a0c54"
  },
  "time": {
    "__type": "Date",
    "iso": "2011-11-11T03:11:11.000Z"
  },
  "objectId": "58a460e78d6d810057e9f616",
  "createdAt": "2017-02-15T14:08:39.892Z",
  "updatedAt": "2017-02-16T10:49:00.176Z"
}
```

`toJSON()` (v2)
```diff
{
  "b": {
-   "__type": "Pointer",
-   "className": "B",
    "foo": "bar",
    "createdAt": "2017-02-15T14:09:21.965Z",
    "updatedAt": "2017-02-15T14:09:21.965Z",
    "objectId": "58a461118d6d8100580a0c54"
  },
- "time": {
-   "__type": "Date",
-   "iso": "2011-11-11T03:11:11.000Z"
- },
+ "time": "2011-11-11T03:11:11.000Z",
  "objectId": "58a460e78d6d810057e9f616",
  "createdAt": "2017-02-15T14:08:39.892Z",
  "updatedAt": "2017-02-16T10:49:00.176Z"
}
```

`toFullJSON()` (v2)
```diff
{
+ __type: 'Object',
+ className: 'A',
  "b": {
    "__type": "Pointer",
    "className": "B",
    "foo": "bar",
    "createdAt": "2017-02-15T14:09:21.965Z",
    "updatedAt": "2017-02-15T14:09:21.965Z",
    "objectId": "58a461118d6d8100580a0c54"
  },
  "time": {
    "__type": "Date",
    "iso": "2011-11-11T03:11:11.000Z"
  },
  "objectId": "58a460e78d6d810057e9f616",
  "createdAt": "2017-02-15T14:08:39.892Z",
  "updatedAt": "2017-02-16T10:49:00.176Z"
}
```

需要特别提出的是，`#toJSON` 方法，与 native SDK 的 `toJSONObject` 不同的是，不会包含 `className` 字段。我觉得 className 算 meta data，并且如果需要可以使用 `#toFullJSON()`，这里就保持这个行为了。

close #383 。