### PR TITLE
fix(Weapp): handle failed wx.login

### DIFF
--- a/src/user.js
+++ b/src/user.js
@@ -16,6 +16,7 @@ const getWeappLoginCode = () => {
           reject(new Error(errMsg));
         }
       },
+      fail: () => reject(new Error('wx.login 失败')),
     });
   });
 };


### PR DESCRIPTION
https://forum.leancloud.cn/t/bug/15205

微信的文档没有关于 fail 参数的说明，也不知道什么时候会进入 fail，只能希望是这里的问题。