### PR TITLE
fix ts error at 2.3.4

### DIFF
--- a/storage.d.ts
+++ b/storage.d.ts
@@ -288,6 +288,7 @@ declare namespace AV {
         previousAttributes(): any;
         relation(attr: string): Relation;
         remove(attr: string, item: any): any;
+        save<T>(arg1?: any, options?: Object.SaveOptions): Promise<T>;
         save<T>(options?: Object.SaveOptions, arg2?: any, arg3?: any): Promise<T>;
         set(key: string, value: any, options?: Object.SetOptions): boolean;
         setACL(acl: ACL, options?: Object.SetOptions): boolean;
@@ -572,7 +573,7 @@ declare namespace AV {
         refreshSessionToken(options?: AuthOptions): Promise<User>;
 
         getRoles(options?: AuthOptions): Promise<Role>;
-        
+
         follow(user: User|string, authOptions?: AuthOptions): Promise<void>;
         follow(options: { user: User|string, attributes?: Object}, authOptions?: AuthOptions): Promise<void>;
         unfollow(user: User|string, authOptions?: AuthOptions): Promise<void>;
@@ -764,7 +765,7 @@ declare namespace AV {
         function run(name: string, data?: any, options?: AuthOptions): Promise<any>;
         function requestSmsCode(data: string|{ mobilePhoneNumber: string, template?: string, sign?: string }, options?: SMSAuthOptions): Promise<void>;
         function verifySmsCode(code: string, phone: string): Promise<void>;
-        function requestCaptcha(options?: CaptchaOptions, authOptions?: AuthOptions): Promise<AV.Captcha>;
+        function requestCaptcha(options?: CaptchaOptions, authOptions?: AuthOptions): Promise<Captcha>;
         function verifyCaptcha(code: string, captchaToken: string): Promise<void>;
     }
 


### PR DESCRIPTION
.save function declaration does not match the usage of `.save()` or `.save({words: 'xxx'}, {})`.