### PR TITLE
feat: add AV.Object.query

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -1410,7 +1410,7 @@ module.exports = function(AV) {
       var newArguments = [className].concat(_.toArray(arguments));
       return AV.Object.extend.apply(NewClassObject, newArguments);
     };
-    NewClassObject['new'] = function(attributes, options){
+    NewClassObject['new'] = function(attributes, options) {
       return new NewClassObject(attributes, options);
     };
     AV.Object._classMap[className] = NewClassObject;
@@ -1419,7 +1419,7 @@ module.exports = function(AV) {
 
   // ES6 class syntax support
   Object.defineProperty(AV.Object.prototype, 'className', {
-    get: function(){
+    get: function() {
       const className = this._className || this.constructor._LCClassName || this.constructor.name;
       // If someone tries to subclass "User", coerce it to the right type.
       if (className === "User") {
@@ -1452,6 +1452,12 @@ module.exports = function(AV) {
     }
     AV.Object._classMap[className] = klass;
   };
+
+  Object.defineProperty(AV.Object, 'query', {
+    get() {
+      return new AV.Query(this.prototype.className);
+    },
+  });
 
   AV.Object._findUnsavedChildren = function(object, children, files) {
     AV._traverse(object, function(object) {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -107,7 +107,10 @@ const inherits = function inherits(parent, protoProps, staticProps) {
   }
 
   // Inherit class (static) properties from parent.
-  _.extend(child, parent);
+  for (const prop of Object.getOwnPropertyNames(parent)) {
+    const propertyDescriptor = Object.getOwnPropertyDescriptor(parent, prop);
+    Object.defineProperty(child, prop, propertyDescriptor);
+  }
 
   // Set the prototype chain to inherit from `parent`, without calling
   // `parent`'s constructor function.

--- a/storage.d.ts
+++ b/storage.d.ts
@@ -267,6 +267,7 @@ declare namespace AV {
         attributes: any;
         changed: boolean;
         className: string;
+        query: Query;
 
         constructor(className?: string, options?: any);
         constructor(attributes?: string[], options?: any);

--- a/test/object.js
+++ b/test/object.js
@@ -304,12 +304,26 @@ describe('Objects', function(){
     });
   });
 
+  describe('query', () => {
+    it('should get AV.Query instance', () => {
+      const Foo = AV.Object.extend('Foo');
+      expect(Foo.query.className).to.be('Foo');
+      const Bar = Foo.extend('Bar');
+      expect(Bar.query.className).to.be('Bar');
+    });
+    it('should get AV.Query instance with ES6 class', () => {
+      class Foo extends AV.Object {}
+      expect(Foo.query.className).to.be('Foo');
+      class Bar extends Foo {}
+      expect(Bar.query.className).to.be('Bar');
+    });
+  });
+
   describe("Retrieving Objects",function(){
     it("should be the just save Object",function(){
       var GameScore = AV.Object.extend("GameScore");
-      var query = new AV.Query(GameScore);
       debug(objId);
-      return query.get(objId).then(function(result) {
+      return GameScore.query.get(objId).then(function(result) {
         expect(gameScore.id).to.be.ok();
         expect(gameScore.get('objectId')).to.be(gameScore.id);
         expect(gameScore.get('id')).to.be('id');


### PR DESCRIPTION
在 AV.Object 子类上增加一个便捷属性，来创建此类的 AV.Query 实例。