### PR TITLE
added stream in dependence

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "prepublishOnly": "./script/check-version.js"
   },
   "dependencies": {
+    "stream": "0.0.2",
     "debug": "^3.1.0",
     "es6-promise": "^4.0.5",
     "eventemitter3": "^2.0.3",


### PR DESCRIPTION
When I checked  weapp one `./dist/av-weapp.js` ,
I found `require('stream')`, but I didn't see stream in dependences, it won'r work for weapp.