### PR TITLE
refactor(AVObject): simplify get Created/UpdatedAt

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -228,7 +228,7 @@ module.exports = function(AV) {
        * @return {Date}
        */
       getCreatedAt: function() {
-        return this.createdAt || this.get('createdAt');
+        return this.createdAt;
       },
 
       /**
@@ -236,7 +236,7 @@ module.exports = function(AV) {
        * @return {Date}
        */
       getUpdatedAt: function() {
-        return this.updatedAt || this.get('updatedAt');
+        return this.updatedAt;
       },
 
       /**


### PR DESCRIPTION
`this.get('createdAt')` itself evaluates to
`this.createdAt`,
thus `this.createdAt || this.get('createdAt')` is unnecessary.
The same applies to `getUpdatedAt`.