### PR TITLE
fix(login): typo in type definitions

### DIFF
--- a/storage.d.ts
+++ b/storage.d.ts
@@ -644,7 +644,7 @@ interface UnionOptions {
 interface UnionLoginOptions extends OAuthLoginOptions, UnionOptions {}
 
 interface WeappOptions extends UnionOptions {
-  preferUnion: boolean;
+  preferUnionId: boolean;
 }
 
 interface WeappLoginOptions extends OAuthLoginOptions, WeappOptions {}


### PR DESCRIPTION
Thanks to secoinfo for reporting this.