### PR TITLE
fix: 移除 core 中 Node.js 相关的逻辑

### DIFF
--- a/core.js
+++ b/core.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/cjs/entry/core');
+module.exports = require('./dist/av-core');

--- a/live-query-core.js
+++ b/live-query-core.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/cjs/entry/core-live-query');
+module.exports = require('./dist/av-live-query-core');

--- a/live-query.js
+++ b/live-query.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/cjs/entry/index-live-query');
+module.exports = require('./dist/node/entry/index-live-query');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "leancloud-storage",
   "version": "4.5.3",
-  "main": "./dist/cjs/entry/index.js",
+  "main": "./dist/node/entry/index.js",
   "description": "LeanCloud JavaScript SDK.",
   "repository": {
     "type": "git",
@@ -14,12 +14,12 @@
     "test:node": "cross-env NODE_ENV=test nyc --reporter lcov --reporter text mocha --timeout 300000 test/index.js",
     "test:real": "cross-env REAL_BACKEND=1 npm run test:node",
     "docs": "jsdoc src README.md package.json -d docs -c .jsdocrc.json",
-    "build:cjs": "babel src --out-dir dist/cjs",
+    "build:node": "cross-env PLATFORM=NODE_JS babel src --out-dir dist/node",
     "build:core": "cross-env webpack --config webpack/core.js",
-    "build:browser": "cross-env CLIENT_PLATFORM=Browser webpack --config webpack/browser.js",
-    "build:weapp": "cross-env CLIENT_PLATFORM=Weapp webpack --config webpack/weapp.js",
+    "build:browser": "cross-env PLATFORM=Browser webpack --config webpack/browser.js",
+    "build:weapp": "cross-env PLATFORM=Weapp webpack --config webpack/weapp.js",
     "build:platforms": "npm run build:core && npm run build:browser && npm run build:weapp",
-    "build": "rimraf dist && npm run build:cjs && npm run build:platforms && cross-env LIVE_QUERY=1 npm run build:platforms",
+    "build": "rimraf dist && npm run build:node && npm run build:platforms && cross-env LIVE_QUERY=1 npm run build:platforms",
     "prepublishOnly": "./script/check-version.js"
   },
   "dependencies": {
@@ -76,14 +76,14 @@
     "@leancloud/platform-adapters-node": "@leancloud/platform-adapters-browser",
     "./src/utils/parse-base64.js": "./src/utils/parse-base64-browser.js",
     "./src/ua/comments.js": "./src/ua/comments-browser.js",
-    "./dist/cjs/entry/index.js": "./dist/av-min.js"
+    "./dist/node/entry/index.js": "./dist/av-min.js"
   },
   "react-native": {
-    "./dist/cjs/entry/index.js": "./dist/av-rn-min.js"
+    "./dist/node/entry/index.js": "./dist/av-core.js"
   },
   "weapp": {
     "@leancloud/platform-adapters-node": "@leancloud/platform-adapters-weapp",
-    "./dist/cjs/entry/index.js": "./dist/av-weapp-min.js"
+    "./dist/node/entry/index.js": "./dist/av-weapp-min.js"
   },
   "typings": "./storage.d.ts",
   "types": "./storage.d.ts",

--- a/package.json
+++ b/package.json
@@ -76,14 +76,14 @@
     "@leancloud/platform-adapters-node": "@leancloud/platform-adapters-browser",
     "./src/utils/parse-base64.js": "./src/utils/parse-base64-browser.js",
     "./src/ua/comments.js": "./src/ua/comments-browser.js",
-    "./dist/node/entry/index.js": "./dist/av-min.js"
+    "./dist/node/entry/index.js": "./dist/av.js"
   },
   "react-native": {
     "./dist/node/entry/index.js": "./dist/av-core.js"
   },
   "weapp": {
     "@leancloud/platform-adapters-node": "@leancloud/platform-adapters-weapp",
-    "./dist/node/entry/index.js": "./dist/av-weapp-min.js"
+    "./dist/node/entry/index.js": "./dist/av-weapp.js"
   },
   "typings": "./storage.d.ts",
   "types": "./storage.d.ts",

--- a/src/captcha.js
+++ b/src/captcha.js
@@ -60,7 +60,7 @@ module.exports = AV => {
     );
   };
 
-  if (process.env.CLIENT_PLATFORM === 'Browser') {
+  if (process.env.PLATFORM === 'Browser') {
     /**
      * Bind the captcha to HTMLElements. <b>ONLY AVAILABLE in browsers</b>.
      * @param [elements]

--- a/src/entry/use-adapters.js
+++ b/src/entry/use-adapters.js
@@ -1,7 +1,7 @@
 const adapters = require('@leancloud/platform-adapters-node');
 const getUA = require('../ua');
-const comments = (process.env.CLIENT_PLATFORM
-  ? [process.env.CLIENT_PLATFORM]
+const comments = (process.env.PLATFORM === 'NODE_JS'
+  ? [process.env.PLATFORM]
   : []
 ).concat(require('../ua/comments'));
 

--- a/src/init.js
+++ b/src/init.js
@@ -78,7 +78,7 @@ AV.init = function init(options, ...params) {
     );
   if (!appId) throw new TypeError('appId must be a string');
   if (!appKey) throw new TypeError('appKey must be a string');
-  if (process.env.CLIENT_PLATFORM && masterKey)
+  if (process.env.PLATFORM !== 'NODE_JS' && masterKey)
     console.warn('MasterKey is not supposed to be used at client side.');
   if (isCNApp(appId)) {
     if (!serverURLs && isEmpty(AV._config.serverURLs)) {
@@ -131,7 +131,7 @@ AV.init = function init(options, ...params) {
 };
 
 // If we're running in node.js, allow using the master key.
-if (!process.env.CLIENT_PLATFORM) {
+if (process.env.PLATFORM === 'NODE_JS') {
   AV.Cloud = AV.Cloud || {};
   /**
    * Switches the LeanCloud SDK to using the Master key.  The Master key grants

--- a/src/request.js
+++ b/src/request.js
@@ -53,7 +53,7 @@ const setHeaders = (authOptions = {}, signKey) => {
   if (AV._config.production !== null) {
     headers['X-LC-Prod'] = String(AV._config.production);
   }
-  headers[!process.env.CLIENT_PLATFORM ? 'User-Agent' : 'X-LC-UA'] =
+  headers[process.env.PLATFORM === 'NODE_JS' ? 'User-Agent' : 'X-LC-UA'] =
     AV._sharedConfig.userAgent;
 
   return Promise.resolve().then(() => {

--- a/webpack/common.js
+++ b/webpack/common.js
@@ -57,7 +57,7 @@ exports.create = () => ({
     ],
   },
   plugins: [
-    new webpack.EnvironmentPlugin(['CLIENT_PLATFORM']),
+    new webpack.EnvironmentPlugin(['PLATFORM']),
     new webpack.optimize.UglifyJsPlugin({
       include: /-min\.js$/,
       sourceMap: true,


### PR DESCRIPTION
这个 PR 做了下面这些改动：

- 直接用 Babel 转译得到的 dist/cjs 改为 dist/node，将其视为 Node.js 版本（其中包含了部分只有 Node.js 中能运行的逻辑）。
- 修改代码中 Node.js-only 部分的判定条件，只在 Node.js 版本中出现。
- `./core` 指向 `dist/av-core.js`。`dist/av-core.js` 是真正的 platform 无关 build。
- 如果 React Native 直接引入 "leancloud-storage"（而非 core），将其 redirect 到 core.js。
- （顺带）将浏览器与微信小程序的入口改成未 minify 的版本。

能解决：

- 部分不支持改写 User-Agent header 的 platform 无法使用 core 的问题
- React Native 引用了 `leancloud-storage/core` 但是提示没有 stream 模块的问题（Node.js-only 逻辑）