### PR TITLE
feat: deploy v5 docs as well

### DIFF
--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -6,6 +6,14 @@ cp -r docs gh_pages/;
 mkdir gh_pages/dist;
 cp -r dist/av* gh_pages/dist/;
 cp -r demo gh_pages/;
+
+echo "Deploy doss(v5) to github pages."
+npm install -g typedoc@0.19
+git checkout v5
+rm -rf docs
+typedoc --options typedoc.json
+cp -r docs gh-pages/docs-v5
+
 cd gh_pages && git init;
 git config user.name "leancloud-bot";
 git config user.email "ci@leancloud.cn";


### PR DESCRIPTION
避免提交到 master 分支时 v5 的文档被覆盖，更新部署文档的脚本。