### PR TITLE
refactor: create Object directly when upload external file

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# Master
+
+### Internal Changes
+
+- 现在保存通过 `AV.File.withURL` 方法创建的文件等同于直接在 \_File 中添加一行数据，不再自动生成 `mime_type`。
+
 # 4.7.0（2020-07-14）
 
 ### Features

--- a/src/file.js
+++ b/src/file.js
@@ -183,6 +183,7 @@ module.exports = function(AV) {
     file.attributes.url = url;
     //Mark the file is from external source.
     file.attributes.metaData.__source = 'external';
+    file.attributes.metaData.size = 0;
     return file;
   };
 
@@ -595,18 +596,13 @@ module.exports = function(AV) {
             };
             this._previousSave = AVRequest(
               'files',
-              this.attributes.name,
+              null,
               null,
               'post',
               data,
               options
             ).then(response => {
-              this.attributes.name = response.name;
-              this.attributes.url = response.url;
               this.id = response.objectId;
-              if (response.size) {
-                this.attributes.metaData.size = response.size;
-              }
               return this;
             });
           }


### PR DESCRIPTION
Detail: leancloud/rfcs#1091

和之前使用上有一点差异：直接创建 Object 时，即便用户不提供 mime_type ，也不会自动根据 name 生成 mime_type 。