### PR TITLE
feat: friendship

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Master
 
+### Features
+
+- 好友
+
 ### Internal Changes
 
 - 现在保存通过 `AV.File.withURL` 方法创建的文件等同于直接在 \_File 中添加一行数据，不再自动生成 `mime_type`。

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ### Features
 
 - 好友
+- 添加 `AV.User#getFollowersAndFollowees` 方法用于查询指定用户的 followers 和 followees 。
 
 ### Internal Changes
 

--- a/src/friendship.js
+++ b/src/friendship.js
@@ -1,0 +1,97 @@
+const _ = require('underscore');
+const { request: LCRequest } = require('./request');
+const { getSessionToken } = require('./utils');
+
+module.exports = function(AV) {
+  /**
+   * Contains functions to deal with Friendship in LeanCloud.
+   * @class
+   */
+  AV.Friendship = {
+    /**
+     * Request friendship.
+     * @since 4.8.0
+     * @param {String | AV.User | Object} options if an AV.User or string is given, it will be used as the friend.
+     * @param {AV.User | string} options.friend The friend (or friend's objectId) to follow.
+     * @param {Object} [options.attributes] key-value attributes dictionary to be used as conditions of followeeQuery.
+     * @param {*} [authOptions]
+     * @return {Promise<void>}
+     */
+    request: function(options, authOptions) {
+      if (!AV.User.current()) {
+        throw new Error('Please signin an user.');
+      }
+      let friend;
+      let attributes;
+      if (options.friend) {
+        friend = options.friend;
+        attributes = options.attributes;
+      } else {
+        friend = options;
+      }
+      const friendObject = _.isString(friend)
+        ? AV.Object.createWithoutData('_User', friend)
+        : friend;
+      return LCRequest({
+        method: 'POST',
+        path: '/users/friendshipRequests',
+        data: AV._encode({
+          user: AV.User.current(),
+          friend: friendObject,
+          friendship: attributes,
+        }),
+        authOptions,
+      });
+    },
+
+    /**
+     * Accept a friendship request.
+     * @since 4.8.0
+     * @param {AV.Object | string | Object} options if an AV.Object or string is given, it will be used as the request in _FriendshipRequest.
+     * @param {AV.Object} options.request The request (or it's objectId) to be accepted.
+     * @param {Object} [options.attributes] key-value attributes dictionary to be used as conditions of {@link AV#followeeQuery}.
+     * @param {AuthOptions} [authOptions]
+     * @return {Promise<void>}
+     */
+    acceptRequest: function(options, authOptions = {}) {
+      if (!getSessionToken(authOptions) && !AV.User.current()) {
+        throw new Error('Please signin an user.');
+      }
+      let request;
+      let attributes;
+      if (options.request) {
+        request = options.request;
+        attributes = options.attributes;
+      } else {
+        request = options;
+      }
+      const requestId = _.isString(request) ? request : request.id;
+      return LCRequest({
+        method: 'PUT',
+        path: '/users/friendshipRequests/' + requestId + '/accept',
+        data: {
+          friendship: AV._encode(attributes),
+        },
+        authOptions,
+      });
+    },
+
+    /**
+     * Decline a friendship request.
+     * @param {AV.Object | string} request The request (or it's objectId) to be declined.
+     * @param {AuthOptions} [authOptions]
+     * @return {Promise<void>}
+     */
+    declineRequest: function(request, authOptions = {}) {
+      if (!getSessionToken(authOptions) && !AV.User.current()) {
+        throw new Error('Please signin an user.');
+      }
+      const requestId = _.isString(request) ? request : request.id;
+      return LCRequest({
+        method: 'PUT',
+        path: '/users/friendshipRequests/' + requestId + '/decline',
+        authOptions,
+      });
+    },
+  };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ require('./push')(AV);
 require('./status')(AV);
 require('./search')(AV);
 require('./insight')(AV);
+require('./friendship')(AV);
 
 AV.Conversation = require('./conversation');
 require('./leaderboard');

--- a/src/user.js
+++ b/src/user.js
@@ -788,6 +788,34 @@ module.exports = function(AV) {
       },
 
       /**
+       * Get the user's followers and followees.
+       * @since 4.8.0
+       * @param {Object} [options]
+       * @param {Number} [options.skip]
+       * @param {Number} [options.limit]
+       * @param {AuthOptions} [authOptions]
+       */
+      getFollowersAndFollowees: function(options, authOptions) {
+        if (!this.id) {
+          throw new Error('Please signin.');
+        }
+        return request({
+          method: 'GET',
+          path: `/users/${this.id}/followersAndFollowees`,
+          query: {
+            skip: options && options.skip,
+            limit: options && options.limit,
+            include: 'follower,followee',
+            keys: 'follower,followee',
+          },
+          authOptions,
+        }).then(({ followers, followees }) => ({
+          followers: followers.map(({ follower }) => AV._decode(follower)),
+          followees: followees.map(({ followee }) => AV._decode(followee)),
+        }));
+      },
+
+      /**
        *Create a follower query to query the user's followers.
        * @since 0.3.0
        * @see AV.User#followerQuery

--- a/storage.d.ts
+++ b/storage.d.ts
@@ -883,6 +883,29 @@ export class User extends Object {
   followeeQuery(): Query<this>;
 }
 
+export class Friendship {
+  static request(
+    friend: User | string,
+    authOptions?: AuthOptions
+  ): Promise<void>;
+  static request(
+    options: { friend: User | string; attributes?: object },
+    authOptions?: AuthOptions
+  ): Promise<void>;
+  static acceptRequest(
+    request: Object | string,
+    authOptions?: AuthOptions
+  ): Promise<void>;
+  static acceptRequest(
+    options: { request: Object | string; attributes?: object },
+    authOptions?: AuthOptions
+  ): Promise<void>;
+  static declineRequest(
+    request: Object | string,
+    authOptions?: AuthOptions
+  ): Promise<void>;
+}
+
 export class Captcha {
   url: string;
   captchaToken: string;
@@ -1222,7 +1245,12 @@ export namespace Cloud {
   function requestSmsCode(
     data:
       | string
-      | { mobilePhoneNumber: string; template?: string; sign?: string; smsType?: 'sms' | 'voice' },
+      | {
+          mobilePhoneNumber: string;
+          template?: string;
+          sign?: string;
+          smsType?: 'sms' | 'voice';
+        },
     options?: SMSAuthOptions
   ): Promise<void>;
   function verifySmsCode(code: string, phone: string): Promise<void>;

--- a/storage.d.ts
+++ b/storage.d.ts
@@ -881,6 +881,10 @@ export class User extends Object {
   ): Promise<void>;
   followerQuery(): Query<this>;
   followeeQuery(): Query<this>;
+  getFollowersAndFollowees(
+    options?: { skip?: number; limit?: number },
+    authOptions?: AuthOptions
+  ): Promise<{ followers: User[]; followees: User[] }>;
 }
 
 export class Friendship {


### PR DESCRIPTION
原本未计划在 4.x 版本实现「好友」，想了想还是实现一下吧，毕竟 4.x 在 5.0 发布后的很长一段时间内，仍会是主要使用版本。

之前[未完成的实现](https://github.com/leancloud/javascript-sdk/tree/feat/friendship)，放在一起作参考。与其相比：
- 没有重命名 `FriendShipQuery `
- 没有实现特化的 `FriendshipRequest ` Object

---

## JS SDK 双向好友功能内部文档

> 参考：https://leancloud.atlassian.net/wiki/spaces/PROD/pages/1105854465

### 申请成为好友

当前登录用户申请成为 Tom 的好友：
```js
AV.Friendship.request("tom's objectId")
  .then(() => {
    console.log('好友请求发送成功');
  })
  .catch((error) => {
    console.error('好友请求发送失败', error);
  });
```

申请的同时添加属性：
> 这里模仿了 AV.User#follow 的使用风格
```js
AV.Friendship.request({
  friend: "tom's objectId",
  attributes: {
    group: ['husband'],
  },
});
```

### 查询好友申请

如果 Tom 不在线，上线后要查询谁正在添加自己为好友：
```js
const query = new AV.Query('_FriendshipRequest');
query.equalTo('friend', AV.User.current());
query.equalTo('status', 'pending');
query.find().then((requests) => {
  // requests(AV.Object[]) 是所有申请加 Tom 为好友的请求
});
```

### 订阅好友申请

当 Tom 上线时，执行以下代码可以订阅好友申请：
```js
const query = new AV.Query('_FriendshipRequest');
query.equalTo('friend', AV.User.current());
query.equalTo('status', 'pending');
query.subscribe().then((subscription) => {
  subscription.on('create', (request) => {
    console.log(`${request.get('user').id} 申请添加我为好友`);
  });
});
```

订阅当前用户的申请状态变更（被通过、被拒绝）：
```js
const query = new AV.Query('_FriendshipRequest');
query.equalTo('user', AV.User.current());
query.subscribe().then((subscription) => {
  subscription.on('update', (request) => {
    const status = request.get('status');
    if (status === 'accepted') {
      console.log(`${request.get('friend').id} 通过了我的好友申请`);
    }
    if (status === 'declined') {
      console.log(`${request.get('friend').id} 拒绝了我的好友申请`);
    }
  });
});
```

### 通过、拒绝好友申请

> 查询后的 requests 数组成员是普通的 AV.Object 。因为不想添加太多特化的 Object ，这里就用 AV.Friendship 类的静态方法处理好友申请，使用起来也相对灵活。

```js
const query = new AV.Query('_FriendshipRequest');
query.equalTo('friend', AV.User.current());
query.equalTo('status', 'pending');
query.find().then((requests) => {
  // 全部接受
  requests.forEach(AV.Friendship.acceptRequest);
  // 或者全部拒绝
  requests.forEach(AV.Friendship.declineRequest);
  // 接受的同时添加属性
  requests.forEach((request) => {
    AV.Friendship.acceptRequest({
      request,
      attributes: {
        group: ['husband'],
      },
    });
  });
});
```

### 查询好友

> 感觉没必要再进行封装。直接使用 AV.Query 还可以 skip、limit、include，非常方便。

```js
const query = new AV.Query('_Followee');
query.equalTo('user', AV.User.current());
query.equalTo('friendStatus', true);
query.find().then((results) => {
  const friends = results.map(result => result.get('followee'));
});
```

### 删除好友

使用 unfollow 单向删除与 Tom 的好友关系：
```js
AV.User.current().unfollow("Tom's objectId");
```

### 设置自定义属性

```js
const followee = AV.Object.createWithoutData('_Followee', 'ididid');
// 添加属性
followee.set('remark', 'idiot');
// 更新属性
followee.set('group', ['ex']);
// 删除属性
followee.unset('nickname');
```
