### PR TITLE
feat: findAndCount

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -1736,6 +1736,10 @@ module.exports = function(AV) {
                       method: method,
                       path: path,
                       body: json,
+                      params:
+                        options && options.fetchWhenSave
+                          ? { fetchWhenSave: true }
+                          : undefined,
                     };
                   }),
                 },

--- a/src/query.js
+++ b/src/query.js
@@ -380,6 +380,24 @@ module.exports = function(AV) {
       },
 
       /**
+       * Retrieves both AVObjects and total count.
+       *
+       * @since 4.12.0
+       * @param {AuthOptions} options
+       * @return {Promise} A tuple contains results and count.
+       */
+      findAndCount(options) {
+        const params = this._getParams();
+        params.count = 1;
+        const request = this._createRequest(params, options);
+
+        return request.then(response => [
+          this._parseResponse(response),
+          response.count,
+        ]);
+      },
+
+      /**
        * scan a Query. masterKey required.
        *
        * @since 2.1.0

--- a/storage.d.ts
+++ b/storage.d.ts
@@ -411,7 +411,9 @@ export namespace Object {
     query?: Query<T>;
   }
 
-  interface SaveAllOptions extends AuthOptions {}
+  interface SaveAllOptions extends AuthOptions {
+    fetchWhenSave?: boolean;
+  }
 
   interface SetOptions extends SilentOption {}
 }

--- a/storage.d.ts
+++ b/storage.d.ts
@@ -583,6 +583,7 @@ export class Query<T extends Queriable> extends BaseQuery<T> {
   endsWith(key: string, suffix: string): this;
   equalTo(key: string, value: any): this;
   exists(key: string): this;
+  findAndCount(options?: AuthOptions): Promise<[T[], number]>;
   first(options?: AuthOptions): Promise<T | undefined>;
   get(objectId: string, options?: AuthOptions): Promise<T>;
   greaterThan(key: string, value: any): this;


### PR DESCRIPTION
加了两个功能：

- AV.saveAll 支持 fetchWhenSave
  之前如果 AV.Object 持有未保存的 AV.Object 时会使用 batch 一起保存，这时候 fetchWhenSave 是不生效的，等于还修了个 bug :ease:
- AV.Query#findAndCount

手动测试了一下。