### PR TITLE
fix(type): export AV.Error as an interface

### DIFF
--- a/storage.d.ts
+++ b/storage.d.ts
@@ -1120,279 +1120,273 @@ export enum LeaderboardVersionChangeInterval {
   MONTH,
 }
 
-export class Error {
-  code: number;
-  message: string;
-  rawMessage?: string;
-
-  constructor(code: number, message: string);
-
+export namespace Error {
   /**
    * Error code indicating some error other than those enumerated here.
    */
-  static OTHER_CAUSE: -1;
+  export const OTHER_CAUSE: -1;
 
   /**
    * Error code indicating that something has gone wrong with the server.
    * If you get this error code, it is AV's fault.
    */
-  static INTERNAL_SERVER_ERROR: 1;
+  export const INTERNAL_SERVER_ERROR: 1;
 
   /**
    * Error code indicating the connection to the AV servers failed.
    */
-  static CONNECTION_FAILED: 100;
+  export const CONNECTION_FAILED: 100;
 
   /**
    * Error code indicating the specified object doesn't exist.
    */
-  static OBJECT_NOT_FOUND: 101;
+  export const OBJECT_NOT_FOUND: 101;
 
   /**
    * Error code indicating you tried to query with a datatype that doesn't
    * support it, like exact matching an array or object.
    */
-  static INVALID_QUERY: 102;
+  export const INVALID_QUERY: 102;
 
   /**
    * Error code indicating a missing or invalid classname. Classnames are
    * case-sensitive. They must start with a letter, and a-zA-Z0-9_ are the
    * only valid characters.
    */
-  static INVALID_CLASS_NAME: 103;
+  export const INVALID_CLASS_NAME: 103;
 
   /**
    * Error code indicating an unspecified object id.
    */
-  static MISSING_OBJECT_ID: 104;
+  export const MISSING_OBJECT_ID: 104;
 
   /**
    * Error code indicating an invalid key name. Keys are case-sensitive. They
    * must start with a letter, and a-zA-Z0-9_ are the only valid characters.
    */
-  static INVALID_KEY_NAME: 105;
+  export const INVALID_KEY_NAME: 105;
 
   /**
    * Error code indicating a malformed pointer. You should not see this unless
    * you have been mucking about changing internal AV code.
    */
-  static INVALID_POINTER: 106;
+  export const INVALID_POINTER: 106;
 
   /**
    * Error code indicating that badly formed JSON was received upstream. This
    * either indicates you have done something unusual with modifying how
    * things encode to JSON, or the network is failing badly.
    */
-  static INVALID_JSON: 107;
+  export const INVALID_JSON: 107;
 
   /**
    * Error code indicating that the feature you tried to access is only
    * available internally for testing purposes.
    */
-  static COMMAND_UNAVAILABLE: 108;
+  export const COMMAND_UNAVAILABLE: 108;
 
   /**
    * You must call AV.initialize before using the AV library.
    */
-  static NOT_INITIALIZED: 109;
+  export const NOT_INITIALIZED: 109;
 
   /**
    * Error code indicating that a field was set to an inconsistent type.
    */
-  static INCORRECT_TYPE: 111;
+  export const INCORRECT_TYPE: 111;
 
   /**
    * Error code indicating an invalid channel name. A channel name is either
    * an empty string (the broadcast channel) or contains only a-zA-Z0-9_
    * characters.
    */
-  static INVALID_CHANNEL_NAME: 112;
+  export const INVALID_CHANNEL_NAME: 112;
 
   /**
    * Error code indicating that push is misconfigured.
    */
-  static PUSH_MISCONFIGURED: 115;
+  export const PUSH_MISCONFIGURED: 115;
 
   /**
    * Error code indicating that the object is too large.
    */
-  static OBJECT_TOO_LARGE: 116;
+  export const OBJECT_TOO_LARGE: 116;
 
   /**
    * Error code indicating that the operation isn't allowed for clients.
    */
-  static OPERATION_FORBIDDEN: 119;
+  export const OPERATION_FORBIDDEN: 119;
 
   /**
    * Error code indicating the result was not found in the cache.
    */
-  static CACHE_MISS: 120;
+  export const CACHE_MISS: 120;
 
   /**
    * Error code indicating that an invalid key was used in a nested
    * JSONObject.
    */
-  static INVALID_NESTED_KEY: 121;
+  export const INVALID_NESTED_KEY: 121;
 
   /**
    * Error code indicating that an invalid filename was used for AVFile.
    * A valid file name contains only a-zA-Z0-9_. characters and is between 1
    * and 128 characters.
    */
-  static INVALID_FILE_NAME: 122;
+  export const INVALID_FILE_NAME: 122;
 
   /**
    * Error code indicating an invalid ACL was provided.
    */
-  static INVALID_ACL: 123;
+  export const INVALID_ACL: 123;
 
   /**
    * Error code indicating that the request timed out on the server. Typically
    * this indicates that the request is too expensive to run.
    */
-  static TIMEOUT: 124;
+  export const TIMEOUT: 124;
 
   /**
    * Error code indicating that the email address was invalid.
    */
-  static INVALID_EMAIL_ADDRESS: 125;
+  export const INVALID_EMAIL_ADDRESS: 125;
 
   /**
    * Error code indicating a missing content type.
    */
-  static MISSING_CONTENT_TYPE: 126;
+  export const MISSING_CONTENT_TYPE: 126;
 
   /**
    * Error code indicating a missing content length.
    */
-  static MISSING_CONTENT_LENGTH: 127;
+  export const MISSING_CONTENT_LENGTH: 127;
 
   /**
    * Error code indicating an invalid content length.
    */
-  static INVALID_CONTENT_LENGTH: 128;
+  export const INVALID_CONTENT_LENGTH: 128;
 
   /**
    * Error code indicating a file that was too large.
    */
-  static FILE_TOO_LARGE: 129;
+  export const FILE_TOO_LARGE: 129;
 
   /**
    * Error code indicating an error saving a file.
    */
-  static FILE_SAVE_ERROR: 130;
+  export const FILE_SAVE_ERROR: 130;
 
   /**
    * Error code indicating an error deleting a file.
    */
-  static FILE_DELETE_ERROR: 153;
+  export const FILE_DELETE_ERROR: 153;
 
   /**
    * Error code indicating that a unique field was given a value that is
    * already taken.
    */
-  static DUPLICATE_VALUE: 137;
+  export const DUPLICATE_VALUE: 137;
 
   /**
    * Error code indicating that a role's name is invalid.
    */
-  static INVALID_ROLE_NAME: 139;
+  export const INVALID_ROLE_NAME: 139;
 
   /**
    * Error code indicating that an application quota was exceeded.  Upgrade to
    * resolve.
    */
-  static EXCEEDED_QUOTA: 140;
+  export const EXCEEDED_QUOTA: 140;
 
   /**
    * Error code indicating that a Cloud Code script failed.
    */
-  static SCRIPT_FAILED: 141;
+  export const SCRIPT_FAILED: 141;
 
   /**
    * Error code indicating that a Cloud Code validation failed.
    */
-  static VALIDATION_ERROR: 142;
+  export const VALIDATION_ERROR: 142;
 
   /**
    * Error code indicating that invalid image data was provided.
    */
-  static INVALID_IMAGE_DATA: 150;
+  export const INVALID_IMAGE_DATA: 150;
 
   /**
    * Error code indicating an unsaved file.
    */
-  static UNSAVED_FILE_ERROR: 151;
+  export const UNSAVED_FILE_ERROR: 151;
 
   /**
    * Error code indicating an invalid push time.
    */
-  static INVALID_PUSH_TIME_ERROR: 152;
+  export const INVALID_PUSH_TIME_ERROR: 152;
 
   /**
    * Error code indicating that the username is missing or empty.
    */
-  static USERNAME_MISSING: 200;
+  export const USERNAME_MISSING: 200;
 
   /**
    * Error code indicating that the password is missing or empty.
    */
-  static PASSWORD_MISSING: 201;
+  export const PASSWORD_MISSING: 201;
 
   /**
    * Error code indicating that the username has already been taken.
    */
-  static USERNAME_TAKEN: 202;
+  export const USERNAME_TAKEN: 202;
 
   /**
    * Error code indicating that the email has already been taken.
    */
-  static EMAIL_TAKEN: 203;
+  export const EMAIL_TAKEN: 203;
 
   /**
    * Error code indicating that the email is missing, but must be specified.
    */
-  static EMAIL_MISSING: 204;
+  export const EMAIL_MISSING: 204;
 
   /**
    * Error code indicating that a user with the specified email was not found.
    */
-  static EMAIL_NOT_FOUND: 205;
+  export const EMAIL_NOT_FOUND: 205;
 
   /**
    * Error code indicating that a user object without a valid session could
    * not be altered.
    */
-  static SESSION_MISSING: 206;
+  export const SESSION_MISSING: 206;
 
   /**
    * Error code indicating that a user can only be created through signup.
    */
-  static MUST_CREATE_USER_THROUGH_SIGNUP: 207;
+  export const MUST_CREATE_USER_THROUGH_SIGNUP: 207;
 
   /**
    * Error code indicating that an an account being linked is already linked
    * to another user.
    */
-  static ACCOUNT_ALREADY_LINKED: 208;
+  export const ACCOUNT_ALREADY_LINKED: 208;
 
   /**
    * Error code indicating that a user cannot be linked to an account because
    * that account's id could not be found.
    */
-  static LINKED_ID_MISSING: 250;
+  export const LINKED_ID_MISSING: 250;
 
   /**
    * Error code indicating that a user with a linked (e.g. Facebook) account
    * has an invalid session.
    */
-  static INVALID_LINKED_SESSION: 251;
+  export const INVALID_LINKED_SESSION: 251;
 
   /**
    * Error code indicating that a service being linked (e.g. Facebook or
    * Twitter) is unsupported.
    */
-  static UNSUPPORTED_SERVICE: 252;
+  export const UNSUPPORTED_SERVICE: 252;
 
   /**
    * Error code indicating a real error code is unavailable because
@@ -1400,7 +1394,12 @@ export class Error {
    * Internet Explorer, which strips the body from HTTP responses that have
    * a non-2XX status code.
    */
-  static X_DOMAIN_REQUEST: 602;
+  export const X_DOMAIN_REQUEST: 602;
+}
+export interface Error {
+  code: number;
+  message: string;
+  rawMessage?: string;
 }
 
 /**

--- a/storage.d.ts
+++ b/storage.d.ts
@@ -1396,6 +1396,7 @@ export namespace Error {
    */
   export const X_DOMAIN_REQUEST: 602;
 }
+
 export interface Error {
   code: number;
   message: string;


### PR DESCRIPTION
前景提要：

https://github.com/leancloud/ticket/pull/609/files#diff-dec40c8cf82954eb426791bbfd0c151ce050d78f836fabb5cf4afdaccd1e2566L177
#666 
#324

尝试了一下让 AV.Error 继承 Error，发现有难度。一是目前的 AV.Error 支持直接（不用 new 关键字）调用，如果用  ES6 class 那么就是个 breaking change 了。二是就算用 ES6 的继承，babel 6 对 Error 继承也有 bug： https://github.com/babel/babel/issues/8385 （这个版本暂时不想升 babel 7）。

所以最终改了定义文件，避免用户写出 `error instanceof AV.Error` 这样的 type guard。如果用户需要区分出 AV.Error，单独写一个 isAVError 通过判断 error.code 类型作为 type guard。

