### PR TITLE
feat: make AV.Error constructible and inheritable

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -5,10 +5,25 @@ const _ = require('underscore');
  */
 
 function AVError(code, message) {
-  const error = new Error(message);
-  error.code = code;
-  return error;
+  if (new.target) {
+    const error = new Error(message);
+    Object.setPrototypeOf(error, Object.getPrototypeOf(this));
+    error.code = code;
+    return error;
+  }
+  return new AVError(code, message);
 }
+
+AVError.prototype = Object.create(Error.prototype, {
+  constructor: {
+    value: Error,
+    enumerable: false,
+    writable: true,
+    configurable: true,
+  },
+});
+
+Object.setPrototypeOf(AVError, Error);
 
 _.extend(
   AVError,

--- a/storage.d.ts
+++ b/storage.d.ts
@@ -1126,273 +1126,279 @@ export enum LeaderboardVersionChangeInterval {
   MONTH,
 }
 
-export namespace Error {
+export class Error {
+  code: number;
+  message: string;
+  rawMessage?: string;
+
+  constructor(code: number, message: string);
+
   /**
    * Error code indicating some error other than those enumerated here.
    */
-  export const OTHER_CAUSE: -1;
+  static OTHER_CAUSE: -1;
 
   /**
    * Error code indicating that something has gone wrong with the server.
    * If you get this error code, it is AV's fault.
    */
-  export const INTERNAL_SERVER_ERROR: 1;
+  static INTERNAL_SERVER_ERROR: 1;
 
   /**
    * Error code indicating the connection to the AV servers failed.
    */
-  export const CONNECTION_FAILED: 100;
+  static CONNECTION_FAILED: 100;
 
   /**
    * Error code indicating the specified object doesn't exist.
    */
-  export const OBJECT_NOT_FOUND: 101;
+  static OBJECT_NOT_FOUND: 101;
 
   /**
    * Error code indicating you tried to query with a datatype that doesn't
    * support it, like exact matching an array or object.
    */
-  export const INVALID_QUERY: 102;
+  static INVALID_QUERY: 102;
 
   /**
    * Error code indicating a missing or invalid classname. Classnames are
    * case-sensitive. They must start with a letter, and a-zA-Z0-9_ are the
    * only valid characters.
    */
-  export const INVALID_CLASS_NAME: 103;
+  static INVALID_CLASS_NAME: 103;
 
   /**
    * Error code indicating an unspecified object id.
    */
-  export const MISSING_OBJECT_ID: 104;
+  static MISSING_OBJECT_ID: 104;
 
   /**
    * Error code indicating an invalid key name. Keys are case-sensitive. They
    * must start with a letter, and a-zA-Z0-9_ are the only valid characters.
    */
-  export const INVALID_KEY_NAME: 105;
+  static INVALID_KEY_NAME: 105;
 
   /**
    * Error code indicating a malformed pointer. You should not see this unless
    * you have been mucking about changing internal AV code.
    */
-  export const INVALID_POINTER: 106;
+  static INVALID_POINTER: 106;
 
   /**
    * Error code indicating that badly formed JSON was received upstream. This
    * either indicates you have done something unusual with modifying how
    * things encode to JSON, or the network is failing badly.
    */
-  export const INVALID_JSON: 107;
+  static INVALID_JSON: 107;
 
   /**
    * Error code indicating that the feature you tried to access is only
    * available internally for testing purposes.
    */
-  export const COMMAND_UNAVAILABLE: 108;
+  static COMMAND_UNAVAILABLE: 108;
 
   /**
    * You must call AV.initialize before using the AV library.
    */
-  export const NOT_INITIALIZED: 109;
+  static NOT_INITIALIZED: 109;
 
   /**
    * Error code indicating that a field was set to an inconsistent type.
    */
-  export const INCORRECT_TYPE: 111;
+  static INCORRECT_TYPE: 111;
 
   /**
    * Error code indicating an invalid channel name. A channel name is either
    * an empty string (the broadcast channel) or contains only a-zA-Z0-9_
    * characters.
    */
-  export const INVALID_CHANNEL_NAME: 112;
+  static INVALID_CHANNEL_NAME: 112;
 
   /**
    * Error code indicating that push is misconfigured.
    */
-  export const PUSH_MISCONFIGURED: 115;
+  static PUSH_MISCONFIGURED: 115;
 
   /**
    * Error code indicating that the object is too large.
    */
-  export const OBJECT_TOO_LARGE: 116;
+  static OBJECT_TOO_LARGE: 116;
 
   /**
    * Error code indicating that the operation isn't allowed for clients.
    */
-  export const OPERATION_FORBIDDEN: 119;
+  static OPERATION_FORBIDDEN: 119;
 
   /**
    * Error code indicating the result was not found in the cache.
    */
-  export const CACHE_MISS: 120;
+  static CACHE_MISS: 120;
 
   /**
    * Error code indicating that an invalid key was used in a nested
    * JSONObject.
    */
-  export const INVALID_NESTED_KEY: 121;
+  static INVALID_NESTED_KEY: 121;
 
   /**
    * Error code indicating that an invalid filename was used for AVFile.
    * A valid file name contains only a-zA-Z0-9_. characters and is between 1
    * and 128 characters.
    */
-  export const INVALID_FILE_NAME: 122;
+  static INVALID_FILE_NAME: 122;
 
   /**
    * Error code indicating an invalid ACL was provided.
    */
-  export const INVALID_ACL: 123;
+  static INVALID_ACL: 123;
 
   /**
    * Error code indicating that the request timed out on the server. Typically
    * this indicates that the request is too expensive to run.
    */
-  export const TIMEOUT: 124;
+  static TIMEOUT: 124;
 
   /**
    * Error code indicating that the email address was invalid.
    */
-  export const INVALID_EMAIL_ADDRESS: 125;
+  static INVALID_EMAIL_ADDRESS: 125;
 
   /**
    * Error code indicating a missing content type.
    */
-  export const MISSING_CONTENT_TYPE: 126;
+  static MISSING_CONTENT_TYPE: 126;
 
   /**
    * Error code indicating a missing content length.
    */
-  export const MISSING_CONTENT_LENGTH: 127;
+  static MISSING_CONTENT_LENGTH: 127;
 
   /**
    * Error code indicating an invalid content length.
    */
-  export const INVALID_CONTENT_LENGTH: 128;
+  static INVALID_CONTENT_LENGTH: 128;
 
   /**
    * Error code indicating a file that was too large.
    */
-  export const FILE_TOO_LARGE: 129;
+  static FILE_TOO_LARGE: 129;
 
   /**
    * Error code indicating an error saving a file.
    */
-  export const FILE_SAVE_ERROR: 130;
+  static FILE_SAVE_ERROR: 130;
 
   /**
    * Error code indicating an error deleting a file.
    */
-  export const FILE_DELETE_ERROR: 153;
+  static FILE_DELETE_ERROR: 153;
 
   /**
    * Error code indicating that a unique field was given a value that is
    * already taken.
    */
-  export const DUPLICATE_VALUE: 137;
+  static DUPLICATE_VALUE: 137;
 
   /**
    * Error code indicating that a role's name is invalid.
    */
-  export const INVALID_ROLE_NAME: 139;
+  static INVALID_ROLE_NAME: 139;
 
   /**
    * Error code indicating that an application quota was exceeded.  Upgrade to
    * resolve.
    */
-  export const EXCEEDED_QUOTA: 140;
+  static EXCEEDED_QUOTA: 140;
 
   /**
    * Error code indicating that a Cloud Code script failed.
    */
-  export const SCRIPT_FAILED: 141;
+  static SCRIPT_FAILED: 141;
 
   /**
    * Error code indicating that a Cloud Code validation failed.
    */
-  export const VALIDATION_ERROR: 142;
+  static VALIDATION_ERROR: 142;
 
   /**
    * Error code indicating that invalid image data was provided.
    */
-  export const INVALID_IMAGE_DATA: 150;
+  static INVALID_IMAGE_DATA: 150;
 
   /**
    * Error code indicating an unsaved file.
    */
-  export const UNSAVED_FILE_ERROR: 151;
+  static UNSAVED_FILE_ERROR: 151;
 
   /**
    * Error code indicating an invalid push time.
    */
-  export const INVALID_PUSH_TIME_ERROR: 152;
+  static INVALID_PUSH_TIME_ERROR: 152;
 
   /**
    * Error code indicating that the username is missing or empty.
    */
-  export const USERNAME_MISSING: 200;
+  static USERNAME_MISSING: 200;
 
   /**
    * Error code indicating that the password is missing or empty.
    */
-  export const PASSWORD_MISSING: 201;
+  static PASSWORD_MISSING: 201;
 
   /**
    * Error code indicating that the username has already been taken.
    */
-  export const USERNAME_TAKEN: 202;
+  static USERNAME_TAKEN: 202;
 
   /**
    * Error code indicating that the email has already been taken.
    */
-  export const EMAIL_TAKEN: 203;
+  static EMAIL_TAKEN: 203;
 
   /**
    * Error code indicating that the email is missing, but must be specified.
    */
-  export const EMAIL_MISSING: 204;
+  static EMAIL_MISSING: 204;
 
   /**
    * Error code indicating that a user with the specified email was not found.
    */
-  export const EMAIL_NOT_FOUND: 205;
+  static EMAIL_NOT_FOUND: 205;
 
   /**
    * Error code indicating that a user object without a valid session could
    * not be altered.
    */
-  export const SESSION_MISSING: 206;
+  static SESSION_MISSING: 206;
 
   /**
    * Error code indicating that a user can only be created through signup.
    */
-  export const MUST_CREATE_USER_THROUGH_SIGNUP: 207;
+  static MUST_CREATE_USER_THROUGH_SIGNUP: 207;
 
   /**
    * Error code indicating that an an account being linked is already linked
    * to another user.
    */
-  export const ACCOUNT_ALREADY_LINKED: 208;
+  static ACCOUNT_ALREADY_LINKED: 208;
 
   /**
    * Error code indicating that a user cannot be linked to an account because
    * that account's id could not be found.
    */
-  export const LINKED_ID_MISSING: 250;
+  static LINKED_ID_MISSING: 250;
 
   /**
    * Error code indicating that a user with a linked (e.g. Facebook) account
    * has an invalid session.
    */
-  export const INVALID_LINKED_SESSION: 251;
+  static INVALID_LINKED_SESSION: 251;
 
   /**
    * Error code indicating that a service being linked (e.g. Facebook or
    * Twitter) is unsupported.
    */
-  export const UNSUPPORTED_SERVICE: 252;
+  static UNSUPPORTED_SERVICE: 252;
 
   /**
    * Error code indicating a real error code is unavailable because
@@ -1400,13 +1406,7 @@ export namespace Error {
    * Internet Explorer, which strips the body from HTTP responses that have
    * a non-2XX status code.
    */
-  export const X_DOMAIN_REQUEST: 602;
-}
-
-export interface Error {
-  code: number;
-  message: string;
-  rawMessage?: string;
+  static X_DOMAIN_REQUEST: 602;
 }
 
 /**

--- a/test/error.js
+++ b/test/error.js
@@ -13,9 +13,12 @@ describe('AVError', () => {
 
   it('should be a constructor', () => {
     const error = new AV.Error(-1, 'error message');
+    expect(error).to.be.an(AV.Error);
     expect(error).to.be.an(Error);
+    expect(error.stack).to.be.ok();
     expect(error.code).to.equal(-1);
     expect(error.message).to.equal('error message');
+    expect(error.toString()).to.contain('error message');
   });
 
   it('should be inheritable', () => {

--- a/test/error.js
+++ b/test/error.js
@@ -10,4 +10,23 @@ describe('AVError', () => {
       expect(error.toString()).to.contain('error message');
     }
   });
+
+  it('should be a constructor', () => {
+    const error = new AV.Error(-1, 'error message');
+    expect(error).to.be.an(Error);
+    expect(error.code).to.equal(-1);
+    expect(error.message).to.equal('error message');
+  });
+
+  it('should be inheritable', () => {
+    class UnknownError extends AV.Error {
+      constructor() {
+        super(-1, 'unknown error');
+      }
+    }
+    const error = new UnknownError();
+    expect(error).to.be.an(UnknownError);
+    expect(error).to.be.an(AV.Error);
+    expect(error).to.be.an(Error);
+  });
 });


### PR DESCRIPTION
还是没用 ES6 的继承语法，是为了能同时当作 factory / 构造函数使用。

ES6 class + Proxy 也能实现想要的效果，但 Proxy 没法 polyfill，就放弃了。