### PR TITLE
feat: adapt iOS date string format

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -91,7 +91,7 @@ const inherits = function inherits(parent, protoProps, staticProps) {
   return child;
 };
 
-const parseDate = iso8601 => new Date(iso8601);
+const parseDate = iso8601 => new Date(Date.parse(iso8601));
 
 const setValue = (target, key, value) => {
   // '.' is not allowed in Class keys, escaping is not in concern now.


### PR DESCRIPTION
某些 iOS 设备**可能**不支持使用 `yyyy-MM-ddTHH:mm:ssZ` 格式的字符串创建 Date。

微信开发者工具在新版中[加入了警告](https://developers.weixin.qq.com/community/minihome/doc/00080c6f244718053550067736b401)，每次用上述格式调用 Date 构造函数时就会在控制台打印一条日志，影响开发时的体验。

由于不方便在 adapters 中修改 AV 上面的方法，索性直接改写 AV._parseDate，也同时支持了 react-native 等平台。

```
$ node benchmark.js '2020-01-02T03:04:05.678Z' 10000000
new Date(dateString): 4.375s
new Date(Date.parse(dateString)): 4.687s
```